### PR TITLE
chore: harden publish provenance and backup crypto docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Publish to npm with provenance
         if: github.event_name == 'release' || inputs.publish == true
         working-directory: apps/cli
-        run: npm publish --access public
+        run: npm publish --access public --provenance

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ npx vibebasket apply https://vibebasket.dev/api/bundle/cj2k9x
 
 The CLI is also published on npm as [`vibebasket`](https://www.npmjs.com/package/vibebasket).
 
-For maintainers: keep npm publish credentials in your user-level `~/.npmrc`. The repository deliberately does not rely on a tracked project `.npmrc`.
+For maintainers: keep any local npm credentials in your user-level `~/.npmrc` only when you intentionally need them for a manual local publish or private registry access. The repository deliberately does not rely on a tracked project `.npmrc`.
 
-The repo is now wired for GitHub Actions-based npm publishing in [`.github/workflows/publish.yml`](.github/workflows/publish.yml). After the package is linked once in npm Trusted Publisher settings, releases can publish with npm provenance and without a long-lived publish token.
+The repo is now wired for GitHub Actions-based npm publishing in [`.github/workflows/publish.yml`](.github/workflows/publish.yml). After the package is linked once in npm Trusted Publisher settings, published GitHub releases can publish with npm provenance and without a long-lived publish token. The workflow also keeps a manual `workflow_dispatch` path for maintainers who deliberately need a manual publish run.
 
 ## Where It Fits
 
@@ -292,7 +292,7 @@ Repository guardrails:
 
 - CI runs a repo-level secret scan with `gitleaks`.
 - Executable and config files are checked for `NEXT_PUBLIC_*` usage, and only reviewed allowlisted names are accepted.
-- npm publish credentials should stay in the user-level `~/.npmrc`, never in the repository.
+- local npm credentials, if you use them for a manual publish or private registry access, should stay in the user-level `~/.npmrc`, never in the repository.
 
 Report vulnerabilities via [GitHub Security Advisories](https://github.com/mhmtayberk/VibeBasket/security/advisories/new). See [SECURITY.md](SECURITY.md) for the full threat model.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ VibeBasket is designed around a few simple rules:
 ## What the Project Defends
 
 - immutable bundle IDs, so a shared bundle cannot be silently changed in place
-- encrypted backup-storage credentials using AES-256-GCM with a key derived from `AUTH_SECRET`
+- encrypted backup-storage credentials using AES-256-GCM with a key derived from `AUTH_SECRET`; new records use a per-record random salt and IV, and legacy records remain readable during migration
 - path sanitization on file operations
 - bounded request payloads for bundle creation
 - parameterized database access for catalog search and filtering

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.9.0",
+  "version": "0.9.3",
   "private": true,
   "scripts": {
     "dev": "\"$npm_node_execpath\" ../../scripts/run-next.mjs dev --webpack",

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -7,7 +7,7 @@
 - [Quick Install](https://vibebasket.dev/docs?tab=cli): `npx vibebasket apply <bundle-url>` — one command to set up your entire AI dev stack.
 
 ## Architecture
-- [Monorepo Structure](https://github.com/vibebasket/vibebasket): pnpm workspace with 5 packages — apps/web (Next.js 16), apps/cli (Node.js), packages/core (shared DB + schema), packages/adapters (24 IDE adapters), packages/registry (catalog sync engine).
+- [Monorepo Structure](https://github.com/mhmtayberk/VibeBasket): pnpm workspace with 5 packages — apps/web (Next.js 16), apps/cli (Node.js), packages/core (shared DB + schema), packages/adapters (24 IDE adapters), packages/registry (catalog sync engine).
 - [Database](https://vibebasket.dev/docs?tab=security): SQLite via libSQL with Drizzle ORM. Tables include catalog_items, bundles, catalog_sync_runs, sessions, accounts, verification_tokens, saved_stacks, saved_stack_items, saved_stack_targets, backup_storage_config, and site_config. FTS5 full-text search index on catalog.
 - [Adapter Pattern](https://vibebasket.dev/docs?tab=adapters): BaseAdapter class with shared readConfig, applyMcps, writeConfig, diff methods. 16 adapters use BaseAdapter; 8 with custom logic (Hermes YAML, Codex TOML, RooCode/Void delimiters, Aider/GitHub Copilot no-MCP targets).
 - [Block Delimiter Engine](https://vibebasket.dev/docs?tab=delimiters): `# >>> VIBEBASKET START: id <<<` / `# >>> VIBEBASKET END: id <<<` markers for idempotent file merging. Supports shell comments (#), HTML comments (<!-- -->), and YAML comments (#).
@@ -33,10 +33,10 @@
 - [Configuration](https://vibebasket.dev/docs?tab=self-hosting): 15+ environment variables for auth, storage, and operational settings. SQLite WAL mode with single-writer constraint noted. Helm chart supports existingSecret for credentials.
 
 ## Contributing
-- [Source](https://github.com/vibebasket/vibebasket): MIT licensed. TypeScript strict mode. pnpm >= 9, Node >= 20.
-- [Test Suite](https://github.com/vibebasket/vibebasket): Hundreds of unit/integration tests (Vitest), Playwright browser coverage, and property-based adapter checks via fast-check.
+- [Source](https://github.com/mhmtayberk/VibeBasket): MIT licensed. TypeScript strict mode. pnpm >= 9, Node >= 20.
+- [Test Suite](https://github.com/mhmtayberk/VibeBasket): Hundreds of unit/integration tests (Vitest), Playwright browser coverage, and property-based adapter checks via fast-check.
 - [Adapter Contributions](https://vibebasket.dev/docs?tab=adapters): New IDE adapters extend BaseAdapter. Config path resolution, MCP apply, optional skills/rules support. 24 adapters currently supported.
 
 ## Optional
-- [Changelog](https://github.com/vibebasket/vibebasket/releases): Release notes and version history.
-- [Open Source](https://github.com/vibebasket/vibebasket): MIT License. Contributions welcome.
+- [Changelog](https://github.com/mhmtayberk/VibeBasket/releases): Release notes and version history.
+- [Open Source](https://github.com/mhmtayberk/VibeBasket): MIT License. Contributions welcome.

--- a/apps/web/src/lib/storage/crypto.test.ts
+++ b/apps/web/src/lib/storage/crypto.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("storage crypto", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv("AUTH_SECRET", "test-auth-secret");
+    vi.stubEnv("NODE_ENV", "test");
+  });
+
+  it("round-trips new encrypted payloads with versioned random salt format", async () => {
+    const { decryptValue, encryptValue } = await import("./crypto");
+
+    const plaintext = JSON.stringify({ provider: "s3", secretKey: "sk" });
+    const encoded = encryptValue(plaintext);
+
+    expect(encoded.startsWith("v2:")).toBe(true);
+    expect(decryptValue(encoded)).toBe(plaintext);
+  });
+
+  it("keeps legacy static-salt payloads readable for backward compatibility", async () => {
+    const crypto = await import("node:crypto");
+    const { decryptValue } = await import("./crypto");
+
+    const plaintext = JSON.stringify({ provider: "azure", connectionString: "secret" });
+    const key = crypto.scryptSync("test-auth-secret", "vibebasket-salt", 32);
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+    const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const encoded = Buffer.concat([iv, tag, encrypted]).toString("base64");
+
+    expect(decryptValue(encoded)).toBe(plaintext);
+  });
+});

--- a/apps/web/src/lib/storage/crypto.ts
+++ b/apps/web/src/lib/storage/crypto.ts
@@ -1,11 +1,15 @@
 import crypto from "node:crypto";
 
 const ALGORITHM = "aes-256-gcm";
+const KEY_LENGTH = 32;
+const SALT_LENGTH = 16;
 const IV_LENGTH = 16;
 const TAG_LENGTH = 16;
 const TAG_POSITION = IV_LENGTH;
+const VERSION_PREFIX = "v2:";
+const LEGACY_SALT = "vibebasket-salt";
 
-function getEncryptionKey(): Buffer {
+function getSecret(): string {
   const secret =
     process.env.AUTH_SECRET ||
     (process.env.NODE_ENV !== "production" ? "vibebasket-dev-only-secret-change-me" : null);
@@ -14,27 +18,36 @@ function getEncryptionKey(): Buffer {
     throw new Error("AUTH_SECRET is required for encrypted storage operations.");
   }
 
-  return crypto.scryptSync(secret, "vibebasket-salt", 32);
+  return secret;
+}
+
+function deriveKey(salt: Buffer | string): Buffer {
+  return crypto.scryptSync(getSecret(), salt, KEY_LENGTH);
 }
 
 export function encryptValue(plaintext: string): string {
-  const key = getEncryptionKey();
+  const salt = crypto.randomBytes(SALT_LENGTH);
+  const key = deriveKey(salt);
   const iv = crypto.randomBytes(IV_LENGTH);
   const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
 
   const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
   const tag = cipher.getAuthTag();
 
-  return Buffer.concat([iv, tag, encrypted]).toString("base64");
+  return `${VERSION_PREFIX}${Buffer.concat([salt, iv, tag, encrypted]).toString("base64")}`;
 }
 
 export function decryptValue(encoded: string): string {
-  const key = getEncryptionKey();
-  const buffer = Buffer.from(encoded, "base64");
-
-  const iv = buffer.subarray(0, IV_LENGTH);
-  const tag = buffer.subarray(IV_LENGTH, TAG_POSITION + TAG_LENGTH);
-  const encrypted = buffer.subarray(TAG_POSITION + TAG_LENGTH);
+  const isVersioned = encoded.startsWith(VERSION_PREFIX);
+  const buffer = Buffer.from(
+    isVersioned ? encoded.slice(VERSION_PREFIX.length) : encoded,
+    "base64",
+  );
+  const offset = isVersioned ? SALT_LENGTH : 0;
+  const key = isVersioned ? deriveKey(buffer.subarray(0, SALT_LENGTH)) : deriveKey(LEGACY_SALT);
+  const iv = buffer.subarray(offset, offset + IV_LENGTH);
+  const tag = buffer.subarray(offset + IV_LENGTH, offset + TAG_POSITION + TAG_LENGTH);
+  const encrypted = buffer.subarray(offset + TAG_POSITION + TAG_LENGTH);
 
   const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
   decipher.setAuthTag(tag);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,7 +64,7 @@ The admin panel provides a multi-cloud storage system for database backups with 
 - **Azure Blob Storage**: Via `@azure/storage-blob`.
 - **Google Cloud Storage**: Via `@google-cloud/storage`.
 
-Cloud SDKs are lazily loaded via dynamic `await import()` to prevent Next.js build-time module resolution errors. Storage credentials are encrypted with AES-256-GCM (key derived from `AUTH_SECRET` via `scryptSync`) and stored in the `backup_storage_config` SQLite table. Configuration is managed through the admin panel UI — changing backends does not require a server restart. Scheduled backups can be configured with configurable hourly intervals.
+Cloud SDKs are lazily loaded via dynamic `await import()` to prevent Next.js build-time module resolution errors. Storage credentials are encrypted with AES-256-GCM and a key derived from `AUTH_SECRET` via `scryptSync`; new encrypted records use a per-record random salt and IV, while legacy records remain readable for compatibility. The encrypted payload is stored in the `backup_storage_config` SQLite table. Configuration is managed through the admin panel UI — changing backends does not require a server restart. Scheduled backups can be configured with configurable hourly intervals.
 
 ## Performance & Scalability
 - **Full-Text Search**: Global catalog search uses FTS5 virtual tables with automatic trigger-based content sync and rebuild support. Queries are run through parameterized SQL to prevent injection. FTS5 data column removed to reduce index size; prefix-matching enabled for partial word queries (e.g. "postgr" matches "postgresql").

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,340 +1,56 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project are documented here.
 
-## [0.9.0] — 2026-06-13
-
-### 5 New IDE Targets (24 total)
-- **Cortex Code** (Snowflake): CLI terminal agent. MCP at `~/.snowflake/cortex/mcp.json`, skills at `.cortex/skills/`. Supports user and project scopes.
-- **Goose** (Block / Linux Foundation): CLI/Desktop agent. MCP at `~/.config/goose/config.yaml`. User scope. MCP-only today.
-- **IBM Bob** (IBM): Standalone IDE + Bob Shell. MCP at `~/.bob/mcp_settings.json` (global) and `.bob/mcp.json` (project). Skills at `.bob/skills/`.
-- **CodeBuddy** (Tencent Cloud): IDE + VS Code/JetBrains plugin + CLI. MCP at `~/.codebuddy/.mcp.json` (user) and `.mcp.json` (project). Skills at `.codebuddy/skills/`.
-
-### CLI Enhancements
-- **`vibebasket list`**: New command that scans all 24 IDE targets for installed MCP servers, skills, and rules. Shows per-IDE summary with colored output.
-- **`vibebasket search <query>`**: New command that searches the VibeBasket catalog API from the terminal. Returns up to 10 matching MCP servers, skills, or rules with their names, descriptions, and type badges.
-- **Cross-target capability handling**: When a bundle contains skills/rules but not all selected targets support them, the CLI now warns and continues instead of failing. MCP is applied to all targets; skills/rules are only applied to targets that support them.
-
-### Adapter Accuracy Fixes
-- **Claude Code** now declares `supportsSkills: true` — skills are written to `~/.claude/skills/<id>/SKILL.md` or `./claude/skills/<id>/SKILL.md` for project scope.
-- **Cursor** now declares `supportsRules: true` — rules are written to `.cursor/rules/<id>.md`.
-
-### Documentation Updates
-- ARCHITECTURE.md and PROJECT_OVERVIEW.md updated to reflect 24 IDE targets and 11 skills-capable adapters.
-- CLI docs updated with `list`, `search` commands and `--scope` / `--dry-run` flags.
-
-### Test Coverage
-- 18 new adapter tests for Cortex Code, Goose, IBM Bob, and CodeBuddy
-- 340 total tests (165 web + 50 CLI + 125 adapters) — all passing.
-
----
+This changelog stays intentionally high-signal: it tracks meaningful product and release shifts without repeating volatile counts that are already verified elsewhere by CI, tests, and package metadata.
 
 ## [Unreleased]
 
-### Supply-Chain Publishing
-- **Trusted publishing workflow**: Added `.github/workflows/publish.yml`, which prepares the `vibebasket` CLI for GitHub Actions-based npm publishing with OIDC and npm provenance instead of a long-lived repo token.
-- **Release/package guardrail**: automated CLI publishing now checks that a GitHub release tag matches `apps/cli/package.json` before attempting `npm publish`.
-- **CLI UX honesty**: removed the misleading `search --local (coming soon)` hint from the published CLI surface.
-- **CodeQL warning cleanup**: fixed three open code-scanning warnings by tightening HTML entity decoding order, escaping Goose YAML env values safely, and parsing S3 endpoints by hostname instead of substring matching.
-- **Trusted-publisher runtime hardening**: the publish workflow now runs on Node 24 and verifies the bundled npm CLI version before publish so npm Trusted Publishing requirements are met explicitly.
+- Hardened the npm publish workflow so the provenance-attested path matches the documented release process.
+- Upgraded encrypted backup-storage writes to a versioned per-record random-salt format while keeping legacy records readable.
+- Tightened maintainer docs around trusted publishing, manual dispatch, and local npm credential expectations.
 
-### Repo Guardrails
-- **Secret scanning in CI**: Added a repo-tuned `gitleaks` guardrail so obvious credential leaks fail early before the main verify/build jobs run.
-- **Reviewed public env surface**: Added a dedicated `NEXT_PUBLIC_*` allowlist checker plus focused tests, making new client-exposed env vars an intentional review decision instead of an accidental code path.
+## [0.9.3] — 2026-06-26
 
-### Adapter Verification
-- **24-adapter verification pass**: CLI install verification now understands adapter-native MCP config shapes such as Continue `mcpServers` arrays, OpenCode `mcp`, Zed `context_servers`, and Goose `extensions`.
-- **Cursor / Roo Code / OpenCode parity**: verification and docs now match the real install surfaces for `.cursor/skills`, `.cursor/rules`, `.roo/mcp.json`, Roo global `mcp_settings.json`, `.roo/skills`, `.roo/rules`, `.opencode/skills`, and `AGENTS.md`.
-- **Void scope correction**: Void MCP auto-apply now targets the upstream user-scope `~/.void-editor/mcp.json` location, and VibeBasket no longer advertises unsupported Void Skills/Rules auto-apply until per-feature scope handling exists.
+### Release Integrity & Public Launch Hardening
+- Added GitHub Actions-based npm trusted publishing with provenance-oriented release checks and stricter publish-time validation.
+- Added repo secret scanning and a dedicated `NEXT_PUBLIC_*` guard so accidental client-exposed secrets are caught earlier in CI.
+- Fixed CodeQL-relevant issues in HTML entity handling, Goose YAML escaping, and S3 endpoint parsing.
+- Tightened Docker/runtime validation, launch docs, and public package hygiene for the open-source release surface.
 
-### Launch Hardening
-- **Admin mutation hardening**: admin backup and storage writes now require same-origin mutation checks in addition to admin auth, and focused route tests cover the 403 path plus allowed writes.
-- **Scheduled backup wiring fix**: the admin storage/config fetch path now actually executes due scheduled backups and only records schedule completion after a successful snapshot.
-- **Health endpoint bootstrap fix**: `/api/health` now ensures the SQLite schema exists before checking DB reachability, reducing false 503s on first boot.
-- **Timestamp cleanup correctness**: stale session, verification-token, and expiring bundle cleanup now uses real `Date` cutoffs for timestamp-mode columns instead of raw epoch seconds.
-- **Safer local admin snapshots**: local backup creation now prefers SQLite `VACUUM INTO` snapshots before falling back to file copy.
-- **Workspace TypeScript gate restored**: `pnpm typecheck` now passes across the full monorepo again, and `pnpm verify:ci` plus GitHub Actions CI now include the full workspace typecheck instead of only the web package.
-- **CI toolchain alignment**: GitHub Actions now uses `pnpm@11.7.0`, matching the repository `packageManager` declaration and reducing lockfile/tooling drift between local and CI environments.
-- **Catalog sync operator controls**: Added `CATALOG_FETCH_RETRIES` and `CATALOG_MCP_REGISTRY_TIMEOUT_MS` environment tuning for slow upstream regions, plus a new `pnpm catalog:sync:strict` preflight command that exits non-zero when trusted upstream sources still return sync errors.
-- **Catalog sync observability hardening**: manual sync commands now emit collector-level progress to stderr, sync summaries carry per-source duration/item-count data, and `skills.sh` fetches have their own timeout knob via `CATALOG_SKILLS_TIMEOUT_MS`.
-- **Self-hosting secret-model fix**: Docker Compose now passes through the full OAuth/catalog tuning surface, the Dockerfile pins pnpm to the declared repository version instead of `latest`, and the Helm chart now generates a Secret from `secretEnv` by default while still supporting `existingSecret`.
-- **Docs/UI deployment parity**: Self-hosting docs, README examples, and architecture notes now all use the real Helm contract (`env` for non-secret values, `secretEnv` or `existingSecret` for secrets) instead of outdated `env.AUTH_SECRET` examples.
-- **Repo hygiene cleanup**: The accidentally tracked `packages/core/tsconfig.tsbuildinfo` artifact is being dropped from version control, root ignore rules now cover common package-manager debug logs and deployment metadata, and stale docs references to nonexistent middleware/changesets flows were corrected.
-- **Project-scope rollback fix**: CLI restore now passes the active workspace root into project-scoped adapter writes, closing a subtle path-resolution bug during bundle backup rollback.
-- **Backup listing fix**: Timestamped backup filenames are now parsed structurally instead of via blanket dash replacement, keeping restore inventories sorted and human-readable.
-- **Trust freshness fix**: Catalog trust metadata now preserves persisted `lastSyncedAt` values through the UI trust model, so freshness badges/callouts reflect real sync timing.
-- **Docs capability honesty**: Adapter docs now render explicit target capability labels instead of inferring MCP support from a generic skills boolean, reducing install-surface ambiguity.
-- **CLI flag parity**: README and docs now describe `--force`, `--no-verify`, and project-scoped rollback usage in terms that match the real CLI behavior.
-- **Public base URL hardening**: metadata, sitemap, robots, and bundle URL generation now share one validated resolver, reducing stale-domain and malformed-URL behavior when deployments move.
-- **Saved-stack indexing cleanup**: authenticated `/stacks` surfaces are now marked non-indexable and removed from sitemap/robots, aligning SEO with the product's private profile model.
-- **OS path edge-case hardening**: several adapters now respect `XDG_CONFIG_HOME` and `APPDATA` instead of assuming default config-home layouts, improving cross-OS correctness on customized machines.
-- **Sync scheduling docs honesty**: public docs now state more directly that stale catalog refresh is request-driven and that deterministic recurring freshness should be handled via external scheduling around `pnpm catalog:sync`.
+### Install Correctness & Ops Safety
+- Hardened adapter verification so CLI readback checks match target-native MCP config shapes more accurately.
+- Improved catalog/operator controls with stricter sync validation commands, better source-level status visibility, and clearer self-hosting guidance.
+- Corrected several public docs and metadata surfaces so deployment, Helm, auth, and backup guidance match the real product behavior.
 
-### Public Launch Polish
-- **Saved-stack route contract fix**: authenticated stack reads no longer require a mutation `Origin` header, while `POST`/`PATCH`/`DELETE` continue to enforce same-origin CSRF checks. The route tests now model real browser mutation requests by sending a valid same-origin header.
-- **Docs surface cleanup**: setup docs now use the real GitHub clone URL, self-hosting docs point to the in-repo Helm chart instead of an unverified public chart repository, and README/setup/config docs now describe `CATALOG_REFRESH_TOKEN` consistently.
-- **LLM/public metadata honesty**: `apps/web/public/llms.txt` now avoids stale test-count claims and reflects the real self-hosting surface more accurately.
-- **Contributor first-run polish**: CONTRIBUTING now includes the `.env.example` bootstrap step and uses the correct scoped CLI test command.
+## [0.9.2] — 2026-06-25
 
-### Documentation & Correctness Pass
-- **Docs drift cleanup**: README, setup docs, CLI docs, architecture notes, and memory-bank state were re-audited together instead of only patching the latest changes.
-- **Gemini CLI docs corrected**: public docs now reflect that Gemini CLI supports both MCP settings and filesystem-backed skills via `.gemini/skills`.
-- **Codex CLI docs corrected**: public docs now reflect both user and project `config.toml` surfaces plus the target-native remote HTTP MCP field mapping.
-- **CLI reference honesty**: docs no longer claim a non-existent `vb` shortcut or a positional rollback argument; `apply`, `doctor`, `init`, and `rollback` descriptions now match the real CLI behavior more closely.
+### Adapter & CLI Accuracy
+- Strengthened adapter install correctness, rollback handling, and capability enforcement across the full 24-target matrix.
+- Improved CLI package metadata, npm surface quality, and launch-facing command/docs consistency.
+- Tightened route behavior and public-release defaults around auth, stack access, and admin-facing flows.
 
-### Open-Source Launch & Prod Readiness
-- **GitHub automation**: Added GitHub Actions CI for linting, shared-package builds, web typecheck/build, unit/integration tests, and a Playwright smoke suite.
-- **Security automation**: Added CodeQL analysis workflow and Dependabot config for npm packages and GitHub Actions.
-- **Community hygiene**: Added a PR template, Code of Conduct, and a production readiness checklist for public releases and self-hosted launches.
-- **Docs honesty pass**: Updated README, CONTRIBUTING, SECURITY, and SETUP docs to reflect the real verification surface, including the current reliance on `pnpm verify:ci` instead of a monorepo-wide `tsc -b` gate.
-- **Pre-prod security/docs hardening**: Corrected public docs that overstated catalog size or implied the hosted app never stores any encrypted admin credentials, added HSTS and stricter response headers in production, and stopped trusting Cloudflare IP headers unless `TRUST_PROXY` is explicitly enabled.
-- **Backup visibility fix**: Corrected async backend-status resolution in the admin storage UI and surfaced a warning when a configured cloud backend is incomplete and runtime falls back to local storage.
-- **Cloud restore support**: Backup restore now uses provider-native download paths for supported cloud storage backends instead of requiring manual out-of-band download.
+## [0.9.1] — 2026-06-15
 
-### Catalog Integrity & Install Reporting
-- **skills.sh fallback hardening**: When sitemap-based discovery is unavailable and the directory page does not expose its embedded skill payload, VibeBasket now falls back to repo crawling for both official and community skills instead of silently collapsing to official-only coverage.
-- **Source-tag normalization**: skills synced from `skills.sh` fallback paths now persist as `skills-sh-official` or `skills-sh-community`, keeping trust badges and source provenance consistent with the UI model.
-- **Collector health accuracy**: Admin operational visibility now groups persisted `skills-sh-official` and `skills-sh-community` rows under the single `skills.sh Directory` collector so coverage counts match reality.
-- **`vibebasket list` install accuracy**: The CLI now inspects adapter-specific skill/rule install surfaces instead of scanning generic shared folders, so reported installs better match each IDE’s real integration path.
+### Catalog, Auth, and Backup Hardening
+- Hardened catalog sync integrity, install verification, backup flows, and admin/storage behavior.
+- Improved launch-readiness docs, security posture, and self-hosting clarity without changing the project’s single-node operating model.
+- Reduced drift between implementation and docs for adapters, bundle behavior, and deployment expectations.
 
-### 5 New IDE Targets (24 total)
-- **Cortex Code** (Snowflake): CLI terminal agent. MCP at `~/.snowflake/cortex/mcp.json`, skills at `.cortex/skills/`. Supports user and project scopes.
-- **Goose** (Block / Linux Foundation): CLI/Desktop agent. MCP at `~/.config/goose/config.yaml`. User scope. MCP-only today.
-- **IBM Bob** (IBM): Standalone IDE + Bob Shell. MCP at `~/.bob/mcp_settings.json` (global) and `.bob/mcp.json` (project). Skills at `.bob/skills/`.
-- **CodeBuddy** (Tencent Cloud): IDE + VS Code/JetBrains plugin + CLI. MCP at `~/.codebuddy/.mcp.json` (user) and `.mcp.json` (project). Skills at `.codebuddy/skills/`.
-- 3 tools could not be added due to lack of public documentation: ForgeCode, CodeArts Agent (Huawei), CodeMaker.
+## [0.9.0] — 2026-06-13
 
-### CLI Enhancements
-- **`vibebasket list`**: New command that scans all 24 IDE targets for installed MCP servers, skills, and rules. Shows per-IDE summary with colored output.
-- **`vibebasket search <query>`**: New command that searches the VibeBasket catalog API from the terminal. Returns top 10 results with type badges and descriptions.
-- **Cross-target capability handling**: When a bundle contains skills/rules but not all selected targets support them, the CLI now warns and continues instead of failing. MCP is applied to all targets; skills/rules are only applied to targets that support them.
+### Major Product Expansion
+- Expanded VibeBasket to 24 adapter-backed AI IDE and CLI targets.
+- Added `vibebasket list` and `vibebasket search` so catalog discovery and local install inspection work from the terminal.
+- Improved cross-target behavior so MCPs, Skills, and Rules are applied only where target capabilities truly exist.
 
-### Adapter Accuracy Fixes
-- **Claude Code** now declares `supportsSkills: true` — skills are written to `~/.claude/skills/<id>/SKILL.md` or `./claude/skills/<id>/SKILL.md` for project scope.
-- **Cursor** now declares `supportsRules: true` — rules are written to `.cursor/rules/<id>.md`.
-
-### Documentation Updates
-- ARCHITECTURE.md and PROJECT_OVERVIEW.md updated to reflect 24 IDE targets and 11 skills-capable adapters.
-- CLI docs updated with `--scope` and `--dry-run` flags (replaced non-existent `--project-root` and `--yes`).
-
-### Test Coverage
-- 18 new adapter tests for Cortex Code, Goose, IBM Bob, and CodeBuddy
-- 340 total tests (165 web + 50 CLI + 125 adapters) — all passing.
-
-### Multi-Cloud Backup Storage System with DB-Backed Config
-- **Six storage backends**: Local Filesystem, AWS S3, Cloudflare R2, DigitalOcean Spaces, Azure Blob Storage, Google Cloud Storage — all with a unified `StorageBackend` interface.
-- **R2 and Spaces piggyback on S3 backend**: S3-compatible protocol means one implementation covers three providers.
-- **AES-256-GCM encrypted credential storage**: API keys and secrets are encrypted with a key derived from `AUTH_SECRET` via `scryptSync` before storing in the SQLite `backup_storage_config` table. Never stored in plaintext.
-- **DB-first configuration**: `BACKUP_STORAGE_BACKEND` env var is still supported as fallback, but credentials stored in the DB take precedence. Changing backends no longer requires a server restart.
-- **Admin panel storage management UI**: Full-width card with a backend selector table (6 rows showing status, active indicator, Setup/Edit button). Credential forms dynamically show the correct fields per backend type (endpoint, bucket, access key, secret key for S3; connection string + container for Azure; bucket + project ID for GCS).
-- **Lazy-loaded cloud SDKs**: `@aws-sdk/client-s3`, `@azure/storage-blob`, and `@google-cloud/storage` are dynamically imported only when their backend is activated. The barrel `index.ts` avoids static re-exports that would trigger Next.js module resolution errors.
-- **Backup operations**: Create timestamped backups, list them, restore (with pre-restore safety backup), and delete — all through server actions with admin-only auth guards.
-- **25 unit + edge case + chaos tests**: Local backup create/list/delete, concurrent backups, missing files, zero-byte files, special characters, non-file entries, factory backend selection for all 6 backends, and graceful DB-not-available fallback.
-
-### Microsoft Entra ID (Azure AD) Auth Provider
-- **New OAuth provider**: Microsoft Entra ID added alongside GitHub, Google, and Apple. Uses `next-auth/providers/microsoft-entra-id` with `/common/` endpoint for personal + work/school accounts.
-- **Provider gating**: `AUTH_MICROSOFT_ENTRA_ID_ENABLED`, `AUTH_MICROSOFT_ENTRA_ID_ID`, `AUTH_MICROSOFT_ENTRA_ID_SECRET`. Included in `.env.example` and `provider-config.test.ts`.
-- **Total 4 providers now**: GitHub, Google, Apple, Microsoft — each independently gateable.
-
-### Admin Panel Redesign
-- **Consistent design system**: Replaced hardcoded `#050505`/`#a855f7` colors with project CSS variables (`--background`, `--accent`, `--foreground`). Removed `rounded-2xl`/`rounded-xl` in favor of global `--radius: 0.125rem` (2px sharp corners).
-- **Leaderboard table**: Converted div-list to proper `<table>` with `<thead>`/`<tbody>`/`<tr>`/`<td>` structure. Headers, alignment, and padding all consistent.
-- **Sync button**: Redesigned with proper hover/disabled states, spinner animation during sync.
-- **Backup card**: Full-width `md:col-span-3` with backend selector table, credential forms, backup operations, and status indicators.
-
-### Sync & Concurrent Operations Hardening
-- **Concurrency analysis**: Verified no data corruption risk during registry sync. Different tables (`catalog_items` vs `saved_stacks` vs `bundles`), SQLite WAL concurrent readers, transactional sync writes, single-flight guard.
-- **Server action robustness**: Dynamic import for `RegistrySyncService` (avoids Next.js bundle issues), null-safe summary fields, `instanceof Error` checks in catch blocks, try/catch on network errors in SyncButton.
-- **18 sync edge case tests**: Auth guards, error types (Error, TypeError, string, object, empty message), zero/max items, source errors, sequential calls, revalidatePath behavior.
-
-### Saved Stack & Profile Enhancements
-- **Interactive Stack Editing**: Replaced the primitive `window.prompt` rename dialog with a fully featured, custom `EditStackDialog` modal. Normal users can now edit stack name and description, add/remove components directly (synced dynamically with their active basket), and toggle target IDEs in a geometric grid. Expanded screen utilization to `max-w-7xl` / `w-[95vw]` to deliver a spacious two-column layout (Components on the left, Target IDEs on the right) with strict **English-only** arayüz copy.
-- **Admin Layout and Navigation Hiding**: Admin users are no longer shown a saved stacks list or the `Save Stack` panel triggers, preventing all administrative footprinting. In its place, we introduced a premium systems widget with a direct redirection action link to the `/admin` console. Dynamically hid the `My Stacks` navigation link from the `AuthMenu` header for administrators, displaying exclusively the `Admin Panel` action button.
-
-### IDE Targets & Automation Upgrades
-- **Integrated Aider, Void, and GitHub Copilot Targets**: Added native adapter integrations for these highly popular coding tools:
-  - **GitHub Copilot**: Supports project-scoped rules and skills inside `.github/copilot-instructions.md` using high-fidelity delimiters.
-  - **Void Editor**: Supports global/project mcp config merging in `mcp_servers.json` and rules/skills inside both `.voidrules` and `.clinerules`.
-  - **Aider**: Supports zero-dependency idempotent `.aider.conf.yml` YAML config mutations (injecting the `read` flag) and rules/skills inside `.aiderinstructions.md`.
-- **CLI Auto-Apply for Skills & Rules**: Reworked the CLI execution pipeline (`apply.ts`, `rollback.ts`) to automatically apply and compile rules and skills right after base config writes, delivering 100% feature-complete automation.
-- **Ecosystem Watchlist Sync**: Registered and documented all 19 supported targets inside `apps/web/src/lib/targets.ts` and the `/docs` adapters layout tab.
-
-### Security & Hardening
-- **Secure Health Check Endpoint**: Implemented a live `/api/health` API route that queries the database via a lightweight Drizzle select (`db.select().from(users).limit(1)`) to verify real system connectivity. Mitigated Denial of Service (DoS) and request flooding risks via an in-memory database status cache with 5s TTL, and enforced strict HTTP no-cache headers. Injected process uptime tracking in seconds (`uptime` field).
-
-- **Information Disclosure Mitigation in Sitemap**: Added `/docs` route to the intelligent `sitemap.ts` generator, and verified that no private user-scoped bundle pages (`/bundle/[id]`) or administrative routes (`/admin`) are exposed to search engine bots, keeping user data confidential.
-- **XSS & LFI/RFI Defenses**: Secured the `/docs` routing context against Local/Remote File Inclusion (LFI/RFI) by strictly validating the tab query parameter against a secure whitelist of allowed tabs. Shielded search inputs from ReDoS and Cross-Site Scripting (XSS) by enforcing a 100-character constraint on the query parameter.
-
-### Self-Hosting & Docker Integration
-- **Multi-stage Production Dockerfile**: Created a lean multi-stage `Dockerfile` based on Node.js 22 Alpine, optimizing image size via Next.js standalone build output, running as a non-root user, and supporting SQLite database persistence via Docker volume mounts.
-- **Docker Compose Setup**: Designed a production-ready `docker-compose.yml` configuration with custom named volume persistence, automated container health checks utilizing the `/api/health` endpoint, and comprehensive inline environment documentation.
-- **Structured .env.example**: Produced a clean, secure `.env.example` template covering all key parameters (Auth.js secrets, OAuth credentials, trust proxies), tracked it under Git, and updated the `.dockerignore` to block accidental secret leaks.
-
-### Documentation & UI Improvements
-- **Expanded Search Scope**: Enriched keywords mapping was added to all guides inside the `/docs` hub, allowing users to successfully search long-tail terms like "Docker", "compose", "volume", "security", "credentials" and locate relevant architectural articles instantly.
-- **GitHub OAuth Redirect Spec**: Expanded the self-hosting documentation inside `/docs?tab=self-hosting` with a dedicated callout explaining how to correctly declare the GitHub OAuth application callback URL (`${NEXTAUTH_URL}/api/auth/callback/github`) in developer environments.
-
----
+### Platform Foundations
+- Added stronger auth/admin flows, backup management, and production-readiness work across the web app and CLI.
+- Refined target capability modeling so public docs and install behavior align with real adapter support surfaces.
 
 ## [0.8.0] — 2026-05-26
 
-### Documentation & UI Hub
-- Redesigned the `/docs` layout grid, sidebar panel (`w-72`), and content sections to dramatically expand vertical margins, bento card paddings (`p-10`), and grid gaps (`gap-12 md:gap-14`), eliminating vertical clutter and delivering a deeply spacious, highly breathing visual environment.
-- Swapped out all standard rounded corner classes (`rounded-lg`, `rounded-md`, etc.) inside `apps/web/src/app/docs/page.tsx` for sharp pixel-perfect geometric corners (`rounded-[2px]`).
-- Added `/docs` route to the main header navigation and footer links on the homepage for unified top-level discoverability.
-- Centered an animated "Made with ♥ by Vibe Coding for Vibe Coders" footer signature inside a dedicated bottom row across both the homepage and docs pages.
-
-### Design System
-- Set the global `--radius` CSS custom property inside `globals.css` to `0.125rem` (2px), instantly enforcing sharp geometric borders across all Shadcn UI components (buttons, input fields, popovers, and dialogs) project-wide.
-- Added surface container color tokens (`--color-surface-container-*`) and spacing tokens to `globals.css` to align the CSS layer with the design system specification.
-- Resolved the Next.js `missing-data-scroll-behavior` route-transition warning by conditionalizing the global smooth-scrolling behavior using the `html[data-scroll-behavior="smooth"]` attribute selector in `globals.css`.
-
-### Security & Performance
-- Implemented SQLite WAL (Write-Ahead Logging) mode during database bootstrap, enabling full reader-writer concurrency and mitigating `SQLITE_BUSY` blocking risks.
-- Integrated Drizzle atomic DB transactions within the `persistCatalog` ingestion cycle, reducing write disk I/O operations and scaling ingestion performance by over 100×.
-- Refactored `apps/web/src/lib/rate-limit.ts` with a dynamic client IP resolver supporting Cloudflare (`cf-connecting-ip`), trust proxy variables (`TRUST_PROXY`), and standard socket fallbacks, preventing client-side IP spoofing rate-limit bypass.
-- Added a lightweight Map garbage-collection sweeper (`cleanupExpiredBuckets`) triggered during rate limiting checks, preventing long-running in-memory leaks.
-
-### IDE Adapters
-- Refactored Roo Code (`.clinerules`), Hermes (`.hermesrules`), and OpenClaw (`.openclawrules`) IDE adapters to use high-fidelity block delimiter wrappers (`>>> VIBEBASKET START/END <<<`), enabling idempotent rule updates without corrupting custom developer modifications.
-- Added **Continue, Roo Code, Hermes, and OpenClaw** IDE/Agent adapters with full MCP and native **Skills (Prompts & Rules)** support.
-- Configured Continue prompts under `.continue/prompts/*.prompt` files, Roo Code rules inside `.clinerules`, Hermes rules in `.hermesrules`, and OpenClaw rules in `.openclawrules`.
-
-### Catalog & Admin
-- Implemented highly secure, dynamic OAuth Admin promotion dynamically assigning `role: "admin"` in user sessions *only* for verified emails matching the `ADMIN_EMAILS` configuration.
-- Created `/admin` server-rendered Bento Stats Dashboard utilizing concurrent Drizzle database aggregation queries and sync status telemetry.
-- Implemented secure Next.js Server Action `triggerSyncAction` executing manual registry synchronization entirely server-side.
-- Highly optimized the catalog API (`/api/catalog`) by migrating the expensive in-memory `ensureCatalogSkillMirrorCleanup()` deduplication step to the `@vibebasket/registry` sync persistence layer.
-- Resolved SQLite database locking (`SQLITE_BUSY`) under high concurrency by introducing `PRAGMA busy_timeout = 5000` to the database bootstrap phase.
-- Hardened Codex CLI TOML adapter to be completely tolerant of single or double quotes around server identifiers in `config.toml`.
-- Implemented independent desktop grid column scrolling with custom scrollbar utilities for `CatalogGrid` and `BasketPanel`.
-
-### Testing
-- Expanded workspace test coverage with a new `rate-limit.test.ts` suite and updated delimiter integration unit tests; all 120 monorepo Vitest tests pass.
-
-### Recent catalog and registry work
-
-- Fixed catalog loading issues caused by unstable DB path resolution.
-- Added deterministic DB resolution from the workspace root.
-- Fixed local dev origin handling for non-`localhost` browsing during Next.js development.
-- Replaced stubbed registry sync assumptions with live trusted-source collectors.
-- Updated official MCP Registry parsing to match the current upstream payload shape.
-- Switched skills ingestion to the public official `skills.sh` surface instead of a brittle API assumption.
-- Added source-level sync isolation so one upstream failure does not collapse the entire catalog refresh.
-- Expanded the local catalog from a tiny seed set to thousands of trusted MCP and skill entries.
-
-### Recent UX and performance work
-
-- Fixed catalog item selection state so selected items are visibly marked.
-- Added proper unselect/toggle behavior for catalog items.
-- Added page-based pagination in both the catalog API and web UI.
-- Limited page size and reset pagination on tab/search changes.
-- Added single-flight sync protection so concurrent catalog requests do not trigger duplicate sync jobs.
-- Added automatic SQLite indexes for the main catalog query paths.
-- Refreshed the homepage and builder UI around a Stitch-inspired technical-editorial visual system.
-- Added a desktop basket panel and a cleaner mobile basket entry flow.
-- Changed stale catalog refresh behavior so normal requests serve cached data immediately while background sync continues separately.
-- Reduced the hero headline scale and converted the AI editor strip into a marquee motion row.
-- Added richer target metadata so the UI can list popular AI editors while the bundle API still validates supported targets only.
-- Added a light fragmented noise treatment to the global background layer.
-- Prevented oversized basket panels by summarizing item counts and collapsing long selections behind an explicit expand action.
-- Expanded the visible target watchlist to include a broader set of popular AI IDEs and agent CLIs without weakening backend validation.
-- Split the basket target area into supported targets and a compact ecosystem watchlist.
-- Added real adapters for Claude Code, Zed, Gemini CLI, Junie, Kiro, and Cline CLI.
-- Replaced abbreviated target labels in the basket panel with full product names.
-- Added a real Codex CLI adapter based on the official `~/.codex/config.toml` MCP surface.
-- Fixed project-scope apply so adapters now receive the actual project root when resolving config paths.
-- Removed `Trae` from the visible target list so the UI no longer advertises a path we do not support.
-- Converted the hero target strip back into a sliding icon-only marquee.
-- Collapsed the temporary watchlist concept now that the visible target list matches the real adapter-backed set.
-- Refreshed the lockfile after the registry package added `js-yaml`, unblocking full workspace verification again.
-- Fixed package manifest gaps that broke full-workspace verification: missing `drizzle-orm`, `nanoid`, `zod`, and `@types/node` declarations in the right workspaces.
-- Fixed the Tailwind plugin import path so `apps/web` production builds no longer fail resolving `tailwindcss-animate`.
-- Hardened adapter typing and registry typing so workspace typecheck now passes cleanly with `exactOptionalPropertyTypes`.
-- Adjusted package type metadata to point at source entrypoints inside the monorepo, which matches the current internal-consumption model and avoids false broken-type surfaces during local verification.
-- Changed empty-catalog behavior so the first catalog request seeds the local verified catalog immediately and runs the slower upstream sync in the background instead of blocking the UI on a full registry refresh.
-- Added stronger homepage metadata, canonical handling, viewport theme color, and JSON-LD structured data for better SEO/readability by crawlers.
-- Deferred non-refresh catalog sync scheduling until after the request path is free so initial reads do not contend with long-running SQLite writes.
-- Added fetch timeouts to upstream registry collectors so slow upstreams fail fast instead of stalling the sync path indefinitely.
-- Changed catalog persistence so partial upstream failures no longer prune previously synced items from healthy sources.
-- Added a server-rendered initial catalog snapshot for the homepage so the catalog no longer depends on client hydration or the first browser-side `/api/catalog` request to escape the loading state.
-- Verified the live dev server returns `8344` MCP entries through `/api/catalog` and renders the first catalog page in Firefox after reload.
-- Fixed registry persistence loss caused by upstream MCP variants sharing the same generated ID; IDs now include canonical runtime/url/args identity.
-- Normalized skills.sh canonical keys through the same helper used by local skill entries, removing case-only duplicate skill IDs.
-- Confirmed live registry sync now produces `24534` persisted rows with `24534` distinct IDs and zero canonical duplicate MCP or skill rows.
-- Protected production `refresh=1` catalog sync behind `CATALOG_REFRESH_TOKEN` to reduce unauthenticated sync DoS/cost risk.
-- Added `/api/catalog/status` plus `pnpm catalog:sync` and `pnpm catalog:sync:dry` so catalog freshness and sync health are inspectable without opening SQLite by hand.
-- Added a registry timeout test and re-ran smoke E2E/edge-case/chaos checks against the live dev server and registry service.
-- Switched registry persistence from one-row-at-a-time upserts to batched upserts.
-- Added item-level freshness/source metadata to catalog rows: `sourceName`, `sourceUrl`, `firstSeenAt`, `lastSeenAt`, and `lastSyncedAt`.
-- Verified a live sync persisted `24630` rows with those freshness fields populated, and `/api/catalog/status` now reports both `latestCatalogItemAt` and `latestCatalogSyncAt`.
-- Added derived trust scoring in the web catalog so items now show `Verified`, `Official`, or `Community` alongside freshness labels.
-- Simplified catalog freshness ordering away from raw `coalesce(...)` SQL snippets after an intermittent dev-console query generation error.
-- Added trust-aware discovery controls and API query params for `trust`, `freshness`, and `sort`, so trust metadata now influences browse results instead of staying display-only.
-- Added `apps/web` test and typecheck scripts, then verified the new catalog discovery helpers with Vitest under the workspace test path.
-- Added a quiet fallback basket storage adapter for non-browser contexts to remove missing-`localStorage` warnings from tests and SSR.
-- Collapsed the catalog filter controls behind a compact disclosure button with active-filter summary pills so the builder stays cleaner by default without hiding current discovery state.
-- Removed visible sync-recency badges from catalog cards, keeping trust focused on `Verified`, `Official`, `Community`, and source provenance.
-- Defaulted the basket target picker to `Claude Code` only and alphabetized the supported target list.
-- Added successful-sync cleanup for legacy null-source catalog rows, then verified live sync now leaves `0` `source_name is null` records in SQLite.
-
-### Recent auth and saved-stack work
-
-- Added Auth.js plus the Drizzle adapter to `apps/web`, using DB-backed sessions against the shared `@vibebasket/core` tables.
-- Added provider gating for GitHub, Google, and Apple via `AUTH_*_ENABLED`, `AUTH_*_ID`, and `AUTH_*_SECRET`, so self-hosted deployments can expose only the providers they actually configure.
-- Added a live `/api/auth/[...nextauth]` route, server-side session helpers, and a signed-in header/account surface on the homepage.
-- Added a sign-in dialog that only renders enabled providers and links users into the authenticated flow without weakening anonymous catalog browsing.
-- Added the first authenticated saved-stack API surface: `GET/POST /api/stacks` plus `GET/PATCH/DELETE /api/stacks/[id]`.
-- Added stack validation helpers and tests for provider gating and stack payload normalization.
-- Hardened auth/saved-stack SQLite upgrades so existing tables are rebuilt transactionally, duplicate legacy auth data fails with explicit messages, and foreign-key enforcement is restored cleanly after migration errors.
-- Removed the visible `Auth disabled` fallback from the homepage header so the auth surface now disappears cleanly when no provider is configured.
-- Fixed production-build SQLite lock contention by ensuring auth-table bootstrap writes happen in the auth route path instead of at module import time.
-- Wired the basket UI into saved-stack flows with save/load/delete/rename controls and a shared saved-stack panel on both the basket and `/stacks` page.
-- Audited the catalog for duplicate skills and character corruption: the live DB currently shows `0` exact duplicate GitHub skill sources (`repo + path + ref`) and `0` obvious mojibake/control-character display-name issues.
-- Tightened GitHub skill canonical identity from `repo + basename(path)` to `repo + full path + ref`, closing a false-merge edge case for nested skill paths.
-- Normalized catalog display text on ingest by stripping control/zero-width characters, normalizing Unicode, and collapsing whitespace before catalog items are stored or rendered.
-- Added source provenance hints to catalog cards so same-named skills are easier to distinguish without unsafe title-based deduplication.
-- Added mirror-aware official skill dedupe so repo-family variants like `*-plugins` no longer appear twice when they expose the same owner/path skill.
-- Added a one-shot catalog hygiene cleanup on the web API path to remove already-persisted official skill mirror duplicates from SQLite before the next healthy full sync.
-- Tuned MCP registry fetch behavior to use a longer dedicated timeout window than the generic source fetch path, and stopped logging background partial-sync source errors on normal catalog requests.
-- Simplified trust scoring so it now reflects source provenance only instead of blending sync timing into the score.
-- Added flatter brand-style target icons to the hero marquee, plus a fixed back-to-top button for long catalog sessions.
-- Hardened CLI apply honesty by flattening workflow-pack content before apply and aborting when selected targets cannot actually install bundled skills, rules, or workflow files yet.
-- Corrected Cursor's user-scope MCP config target to `~/.cursor/mcp.json`.
-- Broadened `skills.sh` ingestion beyond the official page by parsing the public directory surface, while preserving official/community provenance and mirror-aware dedupe.
-- Added live `skills.sh` query enrichment for skill searches in `/api/catalog`, so long-tail searches such as `postgresql` can surface far more community skills without requiring a full-corpus crawl on every sync.
-- Replaced missing/faint marquee icons with downloaded public agent SVGs for supported targets like Cursor, Windsurf, VS Code, Antigravity, Claude Code, Codex, Gemini, Cline, and Kiro.
-- Hardened Auth.js host trust for self-hosted production deployments by requiring explicit `AUTH_TRUST_HOST` instead of always trusting forwarded host headers.
-- Hardened bundle creation against body-size bypasses by enforcing the 100KB limit on the actual request payload, not only the `Content-Length` header.
-- Removed the broken `skills.sh/?q=...` enrichment path after verifying it returned broad leaderboard/global data rather than reliably filtered search results.
-- Switched skills sync to the public `skills.sh` sitemap index and skill sitemaps, which now ingest the full published skills corpus instead of a small homepage subset.
-- Expanded local skill search matching to include `sourceUrl` and raw stored `data`, improving repo/path-based queries like `postgresql`.
-- Fixed large-catalog SQLite pruning by replacing a single huge `NOT IN (...)` delete with chunked stale-row deletes under the parameter limit.
-- Verified a live persisted sync now completes successfully with `20827` MCPs, `19932` skills, `1` rule, `1` workflow, and `0` source errors (`40761` total rows).
-- Added bundle route tests and hardened `/api/bundle` around typed manifest partitioning, missing-item rejection, unsupported-target validation, and real-byte payload limits.
-- Cleaned low-risk code-quality debt across CLI and web surfaces by removing a dead mock catalog file, centralizing auth-required JSON responses, simplifying basket state, and replacing several `any`/non-null shortcuts with explicit typed helpers.
-- Added a lightweight Playwright E2E harness for the homepage/catalog smoke path and verified two browser flows against a live local dev server.
-- Re-validated the app with live smoke timings: homepage around `0.98s`, first-page catalog API around `54ms`, and catalog status around `184ms`.
-- Fixed local verification drift by correcting the shared `ignoreDeprecations` setting and refreshing missing dependencies needed for `next`, `next-auth`, Playwright, and Vitest-based checks on this machine.
-- Added a shared workspace-root Vitest launcher (`scripts/run-vitest.mjs`) and repointed package test scripts to it, eliminating package-local pnpm/Vitest resolution drift during recursive test runs.
-- Added an explicit `apps/web` Vitest config so browser E2E files and `node_modules` fixture tests no longer leak into the unit-test suite.
-- Dropped the Google-hosted Geist font dependency from the app shell, which makes local and CI production builds deterministic without network font fetches.
-- Hardened the Playwright harness to run against an isolated production-like `next start` server with its own test-only auth env, avoiding collisions with an already-running local dev server.
-- Re-verified the full workspace after those changes: `CI=true pnpm -r run typecheck`, `CI=true pnpm -r run test`, `pnpm --filter web lint`, `pnpm --filter web test`, `npx next build`, and `npx playwright test` all pass.
-- Fixed `skills.sh` official/community provenance classification after tracing escaped trailing repo identifiers in the official page parser; a live sync now persists `1771` official skills alongside the broader community corpus.
-- Removed the silent GitHub-skill `ref: "main"` default from manifests and canonical dedupe keys so upstream refs remain honest and mirror cleanup no longer invents branch metadata.
-- Improved `/api/catalog` search ordering so exact and prefix display-name matches rank above broader description/source/data matches.
-- Fixed remote MCP serialization in Cursor, VS Code, Windsurf, and Antigravity by routing config output through the shared MCP merge utility.
-- Tightened adapter capability flags and hardened CLI apply so unsupported bundle scopes or target write failures abort the run instead of reporting a misleading partial success.
-- Added focused regression tests for remote MCP serialization, CLI apply failure modes, and escaped-repo `skills.sh` official classification.
-- Rebuilt the workspace dependency tree after pnpm left local test/lint/typecheck binaries half-linked, then hardened package scripts around a shared workspace-aware Vitest launcher and `pnpm exec` tool resolution.
-- Fixed a client/server boundary regression in the new target capability centralization: web client code now imports adapter capability metadata through a narrow `target-capabilities` path instead of the full adapter index, which restored clean Next.js production builds.
-- Added a shared `isSupportedTargetId()` guard in the web target model so bundle validation, stack normalization, and basket target toggles keep strong `IdeId` typing without leaking stringly-typed checks.
-- Re-verified the hardened tree with passing results for `pnpm --filter @vibebasket/adapters test`, `pnpm --filter web test`, `pnpm --filter web lint`, `CI=true pnpm -r run typecheck`, `CI=true pnpm -r run test`, `pnpm --filter web build`, and `pnpm --filter web exec playwright test`.
-- Added DeepSeek-TUI as a real adapter-backed target using the official `~/.deepseek/mcp.json` MCP surface, including CLI apply/rollback wiring and adapter regression coverage.
-- Clarified the product surface so DeepSeek-TUI is presented as MCP-only today; skills/rules remain unsupported for auto-apply there just like the rest of the current target set.
-- Re-ran a pre-production hardening pass: repo-wide Biome lint is green, `@vibebasket/core`, `@vibebasket/registry`, and `@vibebasket/adapters` builds pass, and focused package/web Vitest suites were re-verified.
-- Fixed a real legacy SQLite bootstrap bug where older `catalog_items` tables missing `description` or `icon` caused FTS initialization to fail during auth/saved-stack schema upgrades.
-- Restored the missing `saved_stack_targets(stack_id, position)` index during bootstrap so migrated databases match the declared Drizzle schema and tests.
-- Stopped the `CodeBuddy` adapter test suite from writing into the real user home directory by redirecting user-scope skill writes to a temp home during tests.
-- Cleaned registry, adapter, and DB typing debt so repo-wide lint/type surfaces are stricter again ahead of the public launch.
+### Catalog, Docs, and Reliability Baseline
+- Launched the docs hub, improved homepage/catalog UX, and stabilized the initial catalog loading path.
+- Added FTS5-backed search, page-based pagination, background catalog refresh, and SQLite concurrency hardening.
+- Expanded the adapter base, strengthened rate limiting and security defaults, and improved self-hosting ergonomics.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -183,7 +183,7 @@ The repository is prepared for npm Trusted Publisher + provenance publishing thr
 5. set workflow filename to `publish.yml`
 6. allow the `npm publish` action
 
-After that, publishing a GitHub release triggers an OIDC-backed `npm publish --access public` flow. npm automatically attaches provenance for trusted publishers, so no long-lived npm token or extra provenance flag is required in the repo workflow.
+After that, publishing a GitHub release triggers an OIDC-backed `npm publish --access public --provenance` flow. The workflow also keeps a manual `workflow_dispatch` path for maintainers who intentionally need a manual publish run. No long-lived npm token is required in the repository for either path.
 
 The publish workflow intentionally runs on Node 24 so the bundled npm CLI satisfies npm's current Trusted Publishing requirement (`npm` 11.5.1+).
 
@@ -240,7 +240,7 @@ pnpm catalog:sync:strict
 - The catalog status route reports current counts, freshness, and the latest recorded sync summary
 - In production, `refresh=1` on `/api/catalog` is protected; callers must send `x-vibebasket-refresh-token` matching `CATALOG_REFRESH_TOKEN`
 - `pnpm catalog:sync` is the safest hook for cron or external schedulers because it records sync audit metadata as well as refreshing catalog rows
-- keep npm publish tokens in `~/.npmrc`, not in repo files or `.env`
+- if you intentionally use a local npm token for a manual publish or private registry access, keep it only in `~/.npmrc`, not in repo files or `.env`
 - adding a new `NEXT_PUBLIC_*` variable is treated as a security-sensitive change; only extend `scripts/check-public-env.mjs` when the value is intentionally safe for client-side exposure
 - request-triggered background refresh is opportunistic; if you need predictable freshness windows, prefer cron/systemd/Kubernetes scheduling around `pnpm catalog:sync`
 - `pnpm catalog:sync:strict` is the safest pre-launch/manual validation command because it fails fast when one of the trusted upstream collectors still has source errors


### PR DESCRIPTION
## Summary
- add `--provenance` to the npm trusted publishing workflow and align maintainer docs with the real release/manual-dispatch surface
- migrate backup credential encryption writes to a versioned per-record random-salt format while keeping legacy records readable
- clean up release-facing version/link/changelog drift in the web/docs surfaces

## Verification
- `pnpm --filter web test`
- `pnpm --filter web typecheck`
- `pnpm --filter web build`
- `pnpm --filter vibebasket build && pnpm --filter vibebasket pack --dry-run`

## Notes
- added a local-only maintainer note under `memory-bank-private/`, but it is excluded locally and not part of this PR
- repo-wide `pnpm --filter web lint` still has an older Biome/config-format backlog outside this change set; this PR does not widen that cleanup surface