### PR TITLE
fix: avoid eager auth loading in admin routes

### DIFF
--- a/apps/web/src/lib/admin-session.test.ts
+++ b/apps/web/src/lib/admin-session.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMock = vi.fn();
+const assertTrustedMutationOriginMock = vi.fn();
+
+vi.mock("@/auth", () => ({
+  auth: authMock,
+}));
+
+vi.mock("@/lib/csrf", () => ({
+  InvalidOriginError: class InvalidOriginError extends Error {},
+  assertTrustedMutationOrigin: assertTrustedMutationOriginMock,
+}));
+
+describe("admin-session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows verified admin sessions", async () => {
+    authMock.mockResolvedValueOnce({
+      user: { id: "1", role: "admin" },
+    });
+
+    const { requireAdminRole } = await import("./admin-session");
+    await expect(requireAdminRole()).resolves.toEqual({ id: "1", role: "admin" });
+    expect(authMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects non-admin sessions", async () => {
+    authMock.mockResolvedValueOnce({
+      user: { id: "1", role: "user" },
+    });
+
+    const { ForbiddenError, requireAdminRole } = await import("./admin-session");
+    await expect(requireAdminRole()).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it("checks trusted mutation origin before role lookup", async () => {
+    authMock.mockResolvedValueOnce({
+      user: { id: "1", role: "admin" },
+    });
+
+    const request = new Request("http://localhost/api/admin");
+    const { requireAdminMutation } = await import("./admin-session");
+
+    await expect(requireAdminMutation(request)).resolves.toEqual({ id: "1", role: "admin" });
+    expect(assertTrustedMutationOriginMock).toHaveBeenCalledWith(request);
+  });
+});

--- a/apps/web/src/lib/admin-session.ts
+++ b/apps/web/src/lib/admin-session.ts
@@ -1,6 +1,9 @@
-import { auth } from "@/auth";
 import { InvalidOriginError, assertTrustedMutationOrigin } from "@/lib/csrf";
 import { NextResponse } from "next/server";
+
+async function loadAuth() {
+  return (await import("@/auth")).auth;
+}
 
 export class ForbiddenError extends Error {
   constructor(message = "Forbidden: Admin access required") {
@@ -14,6 +17,7 @@ export class ForbiddenError extends Error {
  * Throws a ForbiddenError if unauthorized, which can be caught in route handlers or server actions.
  */
 export async function requireAdminRole() {
+  const auth = await loadAuth();
   const session = await auth();
 
   if (!session || !session.user || session.user.role !== "admin") {


### PR DESCRIPTION
## Summary
- lazy-load the auth helper inside `admin-session` so route module evaluation no longer pulls the auth/db stack at build time
- add focused `admin-session` tests to keep admin auth and mutation guards stable
- reduce Coolify/Nixpacks build-time pressure around `@libsql/client` resolution without changing runtime auth behavior

## Why
Coolify was building the repo through Nixpacks and failing during `apps/web build` while collecting route data for `/api/admin/backup/restore`. The failing import chain was effectively:

`route -> admin-session -> auth -> @vibebasket/core -> @libsql/client`

This change defers the auth/db load until the admin guard is actually executed at runtime.

## Verification
- `pnpm --filter web test -- admin-session.test.ts backup/restore/route.test.ts backup/route.test.ts storage/route.test.ts release-readiness/route.test.ts`
- `pnpm --filter web build`

## Notes
- I could not run local Docker verification in this shell because `docker` is not available on the PATH here
- if Coolify is still configured to use Nixpacks, redeploy this commit first; if problems persist, we should inspect whether the app should be switched to Dockerfile mode in Coolify