### PR TITLE
fix: harden public crawl policy and mobile catalog layout

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -22,7 +22,7 @@ async function runCommand(loader: () => Promise<() => Promise<void>>) {
 
 program
   .name("vibebasket")
-  .description("The Ninite for vibe coding. Bundle and apply AI dev setups.")
+  .description("Bundle and apply trusted AI dev setups.")
   .version(packageJson.version ?? "0.0.0");
 
 program

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,5 +1,5 @@
 # VibeBasket
-> The Ninite for Vibe Coding. Bundle trusted MCP servers, agent skills, and project rules into one shareable install command across 24 AI IDEs.
+> Bundle trusted MCP servers, agent skills, and project rules into one shareable install command across supported AI IDEs.
 
 ## Getting Started
 - [Web Catalog](https://vibebasket.dev): Browse a live catalog that syncs tens of thousands of MCP servers, skills, and rules when fully refreshed. Build your basket and generate an install command.

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -14,6 +14,7 @@ import {
   users,
 } from "@vibebasket/core";
 import { desc, sql } from "drizzle-orm";
+import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { AdminSectionNav } from "./AdminSectionNav";
@@ -23,6 +24,12 @@ import { SyncButton } from "./SyncButton";
 import { SystemHealthPanel } from "./SystemHealthPanel";
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
 
 const ADMIN_SECTIONS = [
   { id: "overview", label: "Overview" },

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -2,6 +2,7 @@ import { auth, getEnabledAuthProviders } from "@/auth";
 import { AuthButtons } from "@/components/auth/AuthButtons";
 import { sanitizeCallbackUrl } from "@/lib/safe-redirect";
 import { ShieldCheck } from "lucide-react";
+import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
@@ -12,6 +13,12 @@ type LoginPageProps = {
 };
 
 export const dynamic = "force-dynamic";
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const [session, resolvedSearchParams] = await Promise.all([auth(), searchParams]);

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,3 +1,4 @@
+import { ROBOTS_DISALLOW_PATHS } from "@/lib/seo";
 import { resolvePublicBaseUrl } from "@/lib/public-url";
 import type { MetadataRoute } from "next";
 import { headers } from "next/headers";
@@ -5,9 +6,10 @@ import { headers } from "next/headers";
 export const dynamic = "force-dynamic";
 
 /**
- * Highly secure, dynamic robots.txt builder.
- * Mitigates information leakage by explicitly disallowing crawlers from indexing
- * administrative dashboards, private auth sessions, and user stacks databases.
+ * Dynamic robots.txt builder.
+ * Public pages remain crawlable while private or operational endpoints stay out
+ * of crawler paths. Sensitive UI routes use page-level noindex metadata rather
+ * than robots disallow so search engines can see explicit indexing directives.
  */
 export default async function robots(): Promise<MetadataRoute.Robots> {
   const requestHeaders = await headers();
@@ -21,17 +23,7 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
     rules: {
       userAgent: "*",
       allow: ["/", "/docs"],
-      disallow: [
-        "/stacks",
-        "/stacks/",
-        "/admin",
-        "/admin/",
-        "/api/admin/",
-        "/api/auth/",
-        "/api/stacks/",
-        "/_next/",
-        "/static/",
-      ],
+      disallow: [...ROBOTS_DISALLOW_PATHS],
     },
     sitemap: `${baseUrl.replace(/\/$/, "")}/sitemap.xml`,
   };

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,3 +1,4 @@
+import { PUBLIC_SITEMAP_ROUTES } from "@/lib/seo";
 import { resolvePublicBaseUrl } from "@/lib/public-url";
 import { catalogItems, db } from "@vibebasket/core";
 import { desc } from "drizzle-orm";
@@ -13,9 +14,9 @@ function isMissingCatalogTableError(error: unknown) {
 }
 
 /**
- * Intelligent, dynamic sitemap builder.
- * Resolves the database state to determine catalog sync freshness, exposing
- * only safe, verified public landing pages with dynamic modification headers.
+ * Dynamic sitemap builder.
+ * Emits only explicitly public, indexable routes while still reflecting the
+ * latest catalog sync freshness and the current deployment host automatically.
  */
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const requestHeaders = await headers();
@@ -27,6 +28,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const normalizedBase = baseUrl.replace(/\/$/, "");
 
   let latestUpdate = new Date();
+  const buildEntries = (lastModified: Date): MetadataRoute.Sitemap =>
+    PUBLIC_SITEMAP_ROUTES.map((route) => ({
+      url: `${normalizedBase}${route.path}`,
+      lastModified,
+      changeFrequency: route.changeFrequency,
+      priority: route.priority,
+    }));
+
   try {
     // Fetch the latest sync date from catalog metadata to reflect true content freshness
     const latestSync = await db
@@ -42,20 +51,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
   } catch (error) {
     if (isMissingCatalogTableError(error)) {
-      return [
-        {
-          url: `${normalizedBase}/`,
-          lastModified: latestUpdate,
-          changeFrequency: "hourly",
-          priority: 1.0,
-        },
-        {
-          url: `${normalizedBase}/docs`,
-          lastModified: latestUpdate,
-          changeFrequency: "weekly",
-          priority: 0.9,
-        },
-      ];
+      return buildEntries(latestUpdate);
     }
 
     console.warn(
@@ -64,20 +60,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     );
   }
 
-  return [
-    {
-      url: `${normalizedBase}/`,
-      lastModified: latestUpdate,
-      changeFrequency: "hourly",
-      priority: 1.0,
-    },
-    {
-      url: `${normalizedBase}/docs`,
-      lastModified: latestUpdate,
-      changeFrequency: "weekly",
-      priority: 0.9,
-    },
-  ];
+  return buildEntries(latestUpdate);
 }
 
 export { isMissingCatalogTableError };

--- a/apps/web/src/components/catalog/CatalogGrid.tsx
+++ b/apps/web/src/components/catalog/CatalogGrid.tsx
@@ -262,7 +262,7 @@ export function CatalogGrid({
 
   return (
     <div className="border-t border-border/80">
-      <div className="mx-auto max-w-[1440px] px-4 py-16 sm:px-6 lg:px-8 lg:py-20">
+      <div className="mx-auto max-w-[1440px] px-4 py-16 pb-36 sm:px-6 sm:pb-40 lg:px-8 lg:py-20 lg:pb-20">
         <div className="max-w-3xl">
           <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-accent">
             The Builder

--- a/apps/web/src/components/catalog/ItemCard.tsx
+++ b/apps/web/src/components/catalog/ItemCard.tsx
@@ -47,7 +47,7 @@ function ItemCardRaw({ item }: ItemCardProps) {
           )}
         />
 
-        <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
           <div className="flex min-w-0 items-start gap-3">
             <div
               className={cn(
@@ -59,10 +59,10 @@ function ItemCardRaw({ item }: ItemCardProps) {
             </div>
 
             <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-2">
+              <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
                 <h3
                   className={cn(
-                    "truncate text-base font-semibold transition-colors",
+                    "break-words text-base font-semibold transition-colors sm:truncate",
                     selected ? "text-foreground" : "text-foreground/95",
                   )}
                 >
@@ -107,7 +107,7 @@ function ItemCardRaw({ item }: ItemCardProps) {
 
           <div
             className={cn(
-              "inline-flex h-9 w-9 shrink-0 items-center justify-center border transition-colors",
+              "inline-flex h-9 w-9 shrink-0 self-end items-center justify-center border transition-colors sm:self-auto",
               selected
                 ? "border-accent bg-accent text-accent-foreground"
                 : "border-border/70 bg-background/40 text-muted-foreground group-hover:border-accent/40",

--- a/apps/web/src/components/layout/TopToTopButton.tsx
+++ b/apps/web/src/components/layout/TopToTopButton.tsx
@@ -23,7 +23,7 @@ export function TopToTopButton() {
       aria-label="Back to top"
       onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
       className={cn(
-        "fixed bottom-[calc(env(safe-area-inset-bottom,0px)+5.5rem)] left-4 z-40 inline-flex h-10 w-10 items-center justify-center border border-border/80 bg-card/88 text-muted-foreground backdrop-blur-sm transition-all hover:border-accent/60 hover:text-foreground sm:bottom-5 sm:left-auto sm:right-5 sm:h-11 sm:w-11 lg:bottom-5",
+        "fixed bottom-[calc(env(safe-area-inset-bottom,0px)+6.75rem)] left-4 z-40 inline-flex h-9 w-9 items-center justify-center border border-border/80 bg-card/88 text-muted-foreground backdrop-blur-sm transition-all hover:border-accent/60 hover:text-foreground sm:bottom-5 sm:left-auto sm:right-5 sm:h-11 sm:w-11 lg:bottom-5",
         visible ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-2 opacity-0",
       )}
     >

--- a/apps/web/src/lib/seo.test.ts
+++ b/apps/web/src/lib/seo.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { PUBLIC_SITEMAP_ROUTES, ROBOTS_DISALLOW_PATHS } from "./seo";
+
+describe("seo route policy", () => {
+  it("keeps only explicitly public routes in the sitemap registry", () => {
+    expect(PUBLIC_SITEMAP_ROUTES).toEqual([
+      {
+        path: "/",
+        changeFrequency: "hourly",
+        priority: 1,
+      },
+      {
+        path: "/docs",
+        changeFrequency: "weekly",
+        priority: 0.9,
+      },
+    ]);
+  });
+
+  it("does not disallow the admin UI in robots.txt", () => {
+    expect(ROBOTS_DISALLOW_PATHS).not.toContain("/admin");
+    expect(ROBOTS_DISALLOW_PATHS).not.toContain("/admin/");
+  });
+});

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -1,0 +1,35 @@
+export type SitemapRouteConfig = {
+  path: string;
+  changeFrequency:
+    | "always"
+    | "hourly"
+    | "daily"
+    | "weekly"
+    | "monthly"
+    | "yearly"
+    | "never";
+  priority: number;
+};
+
+export const PUBLIC_SITEMAP_ROUTES: readonly SitemapRouteConfig[] = [
+  {
+    path: "/",
+    changeFrequency: "hourly",
+    priority: 1.0,
+  },
+  {
+    path: "/docs",
+    changeFrequency: "weekly",
+    priority: 0.9,
+  },
+] as const;
+
+export const ROBOTS_DISALLOW_PATHS: readonly string[] = [
+  "/stacks",
+  "/stacks/",
+  "/api/admin/",
+  "/api/auth/",
+  "/api/stacks/",
+  "/_next/",
+  "/static/",
+] as const;

--- a/charts/vibebasket/Chart.yaml
+++ b/charts/vibebasket/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vibebasket
-description: VibeBasket — The Ninite for Vibe Coding. Bundle MCP servers, skills, and rules into one shareable install flow for AI coding tools.
+description: VibeBasket — Bundle MCP servers, skills, and rules into one shareable install flow for AI coding tools.
 type: application
 version: 0.9.0
 appVersion: "0.9.0"


### PR DESCRIPTION
## Summary
- switch admin/login indexing control to page-level noindex while keeping robots.txt crawl policy clean
- centralize sitemap/robots public route policy and remove the old "Ninite" tagline from public surfaces
- tighten mobile catalog spacing so fixed basket/top actions stop overlapping stacked cards

## Verification
- pnpm --filter web test -- src/app/sitemap.test.ts src/lib/seo.test.ts
- pnpm --filter web build