### PR TITLE
fix: satisfy biome checks for seo route policy

### DIFF
--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,5 +1,5 @@
-import { ROBOTS_DISALLOW_PATHS } from "@/lib/seo";
 import { resolvePublicBaseUrl } from "@/lib/public-url";
+import { ROBOTS_DISALLOW_PATHS } from "@/lib/seo";
 import type { MetadataRoute } from "next";
 import { headers } from "next/headers";
 

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,5 +1,5 @@
-import { PUBLIC_SITEMAP_ROUTES } from "@/lib/seo";
 import { resolvePublicBaseUrl } from "@/lib/public-url";
+import { PUBLIC_SITEMAP_ROUTES } from "@/lib/seo";
 import { catalogItems, db } from "@vibebasket/core";
 import { desc } from "drizzle-orm";
 import type { MetadataRoute } from "next";

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -1,13 +1,6 @@
 export type SitemapRouteConfig = {
   path: string;
-  changeFrequency:
-    | "always"
-    | "hourly"
-    | "daily"
-    | "weekly"
-    | "monthly"
-    | "yearly"
-    | "never";
+  changeFrequency: "always" | "hourly" | "daily" | "weekly" | "monthly" | "yearly" | "never";
   priority: number;
 };
 


### PR DESCRIPTION
## Summary
- sort imports in robots and sitemap route metadata files
- format the shared seo route policy type so Biome passes cleanly
- unblock CI after the crawl-policy and mobile catalog changes

## Verification
- /Users/ayberk/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/run-biome.mjs check apps/web/src/app/robots.ts apps/web/src/app/sitemap.ts apps/web/src/lib/seo.ts
- pnpm --filter web build