### PR TITLE
fix: tighten CLI mixed-target verification output

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Bundle trusted MCP servers, agent skills, and project rules into one shareable install command. Apply across 24 AI IDEs and CLI tools with a single link.
 
-[![Version](https://img.shields.io/badge/version-0.9.3-blue)](package.json)
+[![Version](https://img.shields.io/badge/version-0.9.4-blue)](package.json)
 [![npm](https://img.shields.io/npm/v/vibebasket)](https://www.npmjs.com/package/vibebasket)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](tsconfig.base.json)
 [![CI](https://img.shields.io/badge/ci-github_actions-green)](https://github.com/mhmtayberk/VibeBasket/actions/workflows/ci.yml)

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibebasket",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Local installer and inspection CLI for VibeBasket bundles",
   "main": "./dist/index.js",
   "files": ["dist", "README.md"],

--- a/apps/cli/src/install-verification.test.ts
+++ b/apps/cli/src/install-verification.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { formatVerificationSummary } from "./install-verification.js";
+
+describe("formatVerificationSummary", () => {
+  it("omits MCP confirmation when a target did not receive any MCP content", () => {
+    expect(
+      formatVerificationSummary({
+        ok: true,
+        targetId: "github-copilot",
+        displayName: "GitHub Copilot",
+        configPath: "/tmp/demo/.github/copilot-instructions.md",
+        mcpChecked: false,
+        missingMcpIds: [],
+        configReadable: true,
+        skills: {
+          checked: true,
+          verified: true,
+          missingPaths: [],
+          missingMarkerIds: [],
+        },
+        rules: {
+          checked: true,
+          verified: true,
+          missingPaths: [],
+          missingMarkerIds: [],
+        },
+      }),
+    ).toBe("config readback ok, skills confirmed, rules confirmed");
+  });
+
+  it("keeps MCP confirmation when MCP entries were actually checked", () => {
+    expect(
+      formatVerificationSummary({
+        ok: true,
+        targetId: "cursor",
+        displayName: "Cursor",
+        configPath: "/tmp/demo/.cursor/mcp.json",
+        mcpChecked: true,
+        missingMcpIds: [],
+        configReadable: true,
+        skills: {
+          checked: true,
+          verified: true,
+          missingPaths: [],
+          missingMarkerIds: [],
+        },
+        rules: {
+          checked: true,
+          verified: true,
+          missingPaths: [],
+          missingMarkerIds: [],
+        },
+      }),
+    ).toBe("config readback ok, MCP entries confirmed, skills confirmed, rules confirmed");
+  });
+});

--- a/apps/cli/src/install-verification.ts
+++ b/apps/cli/src/install-verification.ts
@@ -26,6 +26,7 @@ export interface InstallVerificationResult {
   targetId: IdeId;
   displayName: string;
   configPath: string;
+  mcpChecked: boolean;
   missingMcpIds: string[];
   configReadable: boolean;
   skills: FeatureVerificationResult;
@@ -98,6 +99,7 @@ export async function verifyTargetInstall(
   const configuredMcpIds = configReadable
     ? new Set(extractConfiguredMcpIds(readBackConfig))
     : new Set<string>();
+  const mcpChecked = expected.mcps.length > 0;
   const missingMcpIds = expected.mcps
     .map((item) => item.id)
     .filter((id) => !configuredMcpIds.has(id));
@@ -114,6 +116,7 @@ export async function verifyTargetInstall(
     targetId,
     displayName: adapter.displayName,
     configPath,
+    mcpChecked,
     missingMcpIds,
     configReadable,
     skills,
@@ -123,7 +126,8 @@ export async function verifyTargetInstall(
 
 export function formatVerificationSummary(result: InstallVerificationResult): string {
   if (result.ok) {
-    const checks: string[] = ["config readback ok", "MCP entries confirmed"];
+    const checks: string[] = ["config readback ok"];
+    if (result.mcpChecked) checks.push("MCP entries confirmed");
     if (result.skills.checked) checks.push("skills confirmed");
     if (result.rules.checked) checks.push("rules confirmed");
     return checks.join(", ");

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ This changelog stays intentionally high-signal: it tracks meaningful product and
 - Upgraded encrypted backup-storage writes to a versioned per-record random-salt format while keeping legacy records readable.
 - Tightened maintainer docs around trusted publishing, manual dispatch, and local npm credential expectations.
 
+## [0.9.4] — 2026-06-30
+
+### CLI Verification Accuracy
+- Fixed CLI post-install verification summaries so targets that do not support MCP configuration no longer report misleading MCP confirmation text.
+- Added focused CLI coverage for mixed-target verification output to keep capability-aware install messaging honest.
+
 ## [0.9.3] — 2026-06-26
 
 ### Release Integrity & Public Launch Hardening


### PR DESCRIPTION
## Summary
- fix CLI verification summaries so MCP confirmation only appears when MCP entries were actually checked
- add focused CLI tests for mixed-target verification output
- bump the published CLI package version to 0.9.4 and record the patch in the changelog

## Verification
- pnpm --filter vibebasket test -- install-verification apply
- pnpm --filter vibebasket build
- real prod bundle create/fetch/apply checks against vibebasket.dev and the published npm CLI
