### PR TITLE
fix: unblock npm publish workflow version check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,8 +47,9 @@ jobs:
 
       - name: Verify npm CLI version
         run: |
-          npm --version
-          node -e "const [major, minor] = process.versions.npm.split('.').map(Number); if (major < 11 || (major === 11 && minor < 5)) { console.error(`npm ${process.versions.npm} is too old for trusted publishing`); process.exit(1); }"
+          npm_version="$(npm --version)"
+          echo "$npm_version"
+          node -e 'const version = process.argv[1]; const [major, minor] = version.split(".").map(Number); if (!version || major < 11 || (major === 11 && minor < 5)) { console.error("npm " + (version || "unknown") + " is too old for trusted publishing"); process.exit(1); }' "$npm_version"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- fix the publish workflow so npm version validation reads the actual npm CLI version safely
- avoid shell interpolation breaking the trusted publishing gate on release runs

## Verification
- inspected the failed v0.9.4 Publish CLI logs
- confirmed the failure came from the npm version check step, not from package publish itself
