### PR TITLE
fix(admin): correct SQLite integrity health detection

### DIFF
--- a/apps/web/src/app/admin/health-actions.test.ts
+++ b/apps/web/src/app/admin/health-actions.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/admin-session", () => ({
+  requireAdminRole: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const { mockSelect, mockAll } = vi.hoisted(() => ({
+  mockSelect: vi.fn(),
+  mockAll: vi.fn(),
+}));
+
+vi.mock("@vibebasket/core", () => ({
+  bundles: {},
+  catalogItems: {},
+  db: {
+    select: mockSelect,
+    all: mockAll,
+  },
+  savedStacks: {},
+  users: {},
+}));
+
+vi.mock("drizzle-orm", () => ({
+  sql: <T = unknown>(strings: TemplateStringsArray) => strings.join("") as T,
+}));
+
+const { requireAdminRole } = await import("@/lib/admin-session");
+const { getDbHealthAction } = await import("./health-actions");
+
+describe("getDbHealthAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAdminRole).mockResolvedValue({ id: "admin", role: "admin" } as never);
+
+    mockSelect.mockImplementation(() => ({
+      from: vi
+        .fn()
+        .mockResolvedValueOnce([{ count: 33271 }])
+        .mockResolvedValueOnce([{ count: 2 }])
+        .mockResolvedValueOnce([{ count: 1 }])
+        .mockResolvedValueOnce([{ count: 0 }]),
+    }));
+  });
+
+  it("treats a classic ok column from PRAGMA integrity_check as healthy", async () => {
+    mockAll.mockResolvedValueOnce([{ ok: "ok" }]);
+
+    const result = await getDbHealthAction();
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("Expected success result");
+    }
+    expect(result.integrityOk).toBe(true);
+  });
+
+  it("treats an integrity_check column from PRAGMA integrity_check as healthy", async () => {
+    mockAll.mockResolvedValueOnce([{ integrity_check: "ok" }]);
+
+    const result = await getDbHealthAction();
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("Expected success result");
+    }
+    expect(result.integrityOk).toBe(true);
+  });
+
+  it("returns unhealthy when PRAGMA integrity_check reports an error message", async () => {
+    mockAll.mockResolvedValueOnce([{ integrity_check: "*** in database main ***" }]);
+
+    const result = await getDbHealthAction();
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("Expected success result");
+    }
+    expect(result.integrityOk).toBe(false);
+  });
+});

--- a/apps/web/src/app/admin/health-actions.ts
+++ b/apps/web/src/app/admin/health-actions.ts
@@ -15,6 +15,18 @@ async function loadDrizzleRuntime() {
   return import("drizzle-orm");
 }
 
+function isIntegrityCheckOk(rows: Array<Record<string, unknown>>) {
+  if (rows.length === 0) {
+    return false;
+  }
+
+  return rows.some((row) =>
+    Object.values(row).some(
+      (value) => typeof value === "string" && value.trim().toLowerCase() === "ok",
+    ),
+  );
+}
+
 export async function getFts5HealthAction() {
   await requireAdmin();
   try {
@@ -57,7 +69,7 @@ export async function getDbHealthAction() {
       db.select({ count: sql<number>`count(*)` }).from(users),
       db.select({ count: sql<number>`count(*)` }).from(savedStacks),
     ]);
-    const integrity = await db.all<{ ok: string }>(sql`PRAGMA integrity_check`);
+    const integrity = await db.all<Record<string, unknown>>(sql`PRAGMA integrity_check`);
 
     return {
       success: true,
@@ -65,7 +77,7 @@ export async function getDbHealthAction() {
       bundles: Number(tableCounts[1][0]?.count ?? 0),
       users: Number(tableCounts[2][0]?.count ?? 0),
       savedStacks: Number(tableCounts[3][0]?.count ?? 0),
-      integrityOk: integrity[0]?.ok === "ok",
+      integrityOk: isIntegrityCheckOk(integrity),
     };
   } catch (error: unknown) {
     return { success: false, error: error instanceof Error ? error.message : "Failed" };


### PR DESCRIPTION
## Summary
- fix admin DB health detection for SQLite integrity check output variants
- avoid false CORRUPT status in the system health panel
- add focused coverage for healthy and unhealthy integrity-check result shapes

## Verification
- pnpm exec vitest run apps/web/src/app/admin/health-actions.test.ts