### PR TITLE
feat(web): add custom 403/404 pages and tighten admin health signals

### DIFF
--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -4,7 +4,8 @@ import {
   classifyCatalogFreshness,
   computeFailureStreak,
 } from "@/lib/admin-ops";
-import { ForbiddenError, requireAdminRole } from "@/lib/admin-session";
+import { shouldRenderAdminForbidden } from "@/lib/admin-access";
+import { requireAdminRole } from "@/lib/admin-session";
 import {
   catalogItems,
   catalogSyncRuns,
@@ -16,7 +17,7 @@ import {
 import { desc, sql } from "drizzle-orm";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { redirect } from "next/navigation";
+import { forbidden } from "next/navigation";
 import { AdminSectionNav } from "./AdminSectionNav";
 import { BackupSectionLazy } from "./BackupSectionLazy";
 import { ReleaseReadinessPanel } from "./ReleaseReadinessPanel";
@@ -49,8 +50,8 @@ export default async function AdminDashboardPage() {
   try {
     await requireAdminRole();
   } catch (error) {
-    if (error instanceof ForbiddenError) {
-      redirect("/");
+    if (shouldRenderAdminForbidden(error)) {
+      forbidden();
     }
   }
 

--- a/apps/web/src/app/forbidden.test.ts
+++ b/apps/web/src/app/forbidden.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { metadata } from "./forbidden";
+
+describe("forbidden metadata", () => {
+  it("is excluded from indexing", () => {
+    expect(metadata.robots).toEqual({
+      index: false,
+      follow: false,
+    });
+  });
+});

--- a/apps/web/src/app/forbidden.tsx
+++ b/apps/web/src/app/forbidden.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { StatusPage } from "../components/layout/StatusPage";
+
+export const metadata: Metadata = {
+  title: "Access Restricted | VibeBasket",
+  description: "You do not have permission to access this VibeBasket page.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function ForbiddenPage() {
+  return (
+    <StatusPage
+      eyebrow="403 · Access restricted"
+      title="You do not have access to this page"
+      summary="This area is reserved for an authorized account in the current environment. Return to the main catalog or sign in with an approved administrator profile."
+      primaryAction={{ href: "/", label: "Back to catalog" }}
+      secondaryAction={{ href: "/login?callbackUrl=%2Fadmin", label: "Open login" }}
+      tone="warning"
+    />
+  );
+}

--- a/apps/web/src/app/not-found.test.ts
+++ b/apps/web/src/app/not-found.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { metadata } from "./not-found";
+
+describe("not-found metadata", () => {
+  it("is excluded from indexing", () => {
+    expect(metadata.robots).toEqual({
+      index: false,
+      follow: false,
+    });
+  });
+});

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import { StatusPage } from "../components/layout/StatusPage";
+
+export const metadata: Metadata = {
+  title: "Page Not Found | VibeBasket",
+  description: "The requested VibeBasket page could not be found.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function NotFoundPage() {
+  return (
+    <StatusPage
+      eyebrow="404 · Missing route"
+      title="Page not found"
+      summary="That route is not available anymore, never existed, or was typed with the wrong path. Head back to the catalog or reopen the docs."
+      primaryAction={{ href: "/", label: "Return home" }}
+      secondaryAction={{ href: "/docs", label: "Open docs" }}
+    />
+  );
+}

--- a/apps/web/src/components/layout/StatusPage.test.tsx
+++ b/apps/web/src/components/layout/StatusPage.test.tsx
@@ -1,0 +1,22 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { StatusPage } from "./StatusPage";
+
+describe("StatusPage", () => {
+  it("renders the supplied title, summary, and actions", () => {
+    const html = renderToStaticMarkup(
+      <StatusPage
+        eyebrow="Test"
+        title="Page not found"
+        summary="The requested page does not exist."
+        primaryAction={{ href: "/", label: "Return home" }}
+        secondaryAction={{ href: "/docs", label: "Open docs" }}
+      />,
+    );
+
+    expect(html).toContain("Page not found");
+    expect(html).toContain("The requested page does not exist.");
+    expect(html).toContain('href="/"');
+    expect(html).toContain('href="/docs"');
+  });
+});

--- a/apps/web/src/components/layout/StatusPage.tsx
+++ b/apps/web/src/components/layout/StatusPage.tsx
@@ -1,0 +1,99 @@
+import { ArrowLeft, ArrowRight, ShieldAlert, TriangleAlert } from "lucide-react";
+import Link from "next/link";
+
+type StatusPageAction = {
+  href: string;
+  label: string;
+};
+
+type StatusPageProps = {
+  eyebrow: string;
+  title: string;
+  summary: string;
+  primaryAction: StatusPageAction;
+  secondaryAction?: StatusPageAction;
+  tone?: "neutral" | "warning";
+};
+
+export function StatusPage({
+  eyebrow,
+  title,
+  summary,
+  primaryAction,
+  secondaryAction,
+  tone = "neutral",
+}: StatusPageProps) {
+  const accentClass = tone === "warning" ? "text-amber-300" : "text-accent";
+  const borderClass =
+    tone === "warning"
+      ? "border-amber-400/30 bg-amber-400/10"
+      : "border-accent/30 bg-accent/10";
+  const Icon = tone === "warning" ? ShieldAlert : TriangleAlert;
+
+  return (
+    <main className="min-h-screen bg-background px-4 py-16 text-foreground sm:px-6 lg:px-8">
+      <div className="mx-auto flex max-w-6xl flex-col gap-10">
+        <div className="flex items-center justify-between gap-4">
+          <Link href="/" className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            VibeBasket
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground transition-colors hover:text-accent"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Home
+          </Link>
+        </div>
+
+        <section className="grid gap-8 border border-border/80 bg-card/70 p-6 lg:grid-cols-[minmax(0,1.15fr)_320px] lg:p-8">
+          <div className="space-y-6">
+            <div
+              className={`inline-flex w-fit items-center gap-2 border px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.16em] ${borderClass} ${accentClass}`}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {eyebrow}
+            </div>
+
+            <div className="space-y-4">
+              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+                {title}
+              </h1>
+              <p className="max-w-2xl text-base leading-8 text-muted-foreground">{summary}</p>
+            </div>
+          </div>
+
+          <div className="flex flex-col justify-between gap-6 border border-border/70 bg-background/40 p-5">
+            <div className="space-y-3">
+              <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                Next step
+              </p>
+              <p className="text-sm leading-7 text-foreground">
+                Head back to a known route, continue browsing the catalog, or reopen the docs.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <Link
+                href={primaryAction.href}
+                className="inline-flex h-11 items-center justify-between gap-2 border border-accent bg-accent/10 px-4 font-mono text-[11px] uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent hover:text-accent-foreground"
+              >
+                {primaryAction.label}
+                <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+              {secondaryAction ? (
+                <Link
+                  href={secondaryAction.href}
+                  className="inline-flex h-11 items-center justify-between gap-2 border border-border/80 bg-background/40 px-4 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground transition-colors hover:border-accent/40 hover:text-foreground"
+                >
+                  {secondaryAction.label}
+                  <ArrowRight className="h-3.5 w-3.5" />
+                </Link>
+              ) : null}
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/lib/admin-access.test.ts
+++ b/apps/web/src/lib/admin-access.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { shouldRenderAdminForbidden } from "./admin-access";
+
+describe("shouldRenderAdminForbidden", () => {
+  it("returns true for ForbiddenError", () => {
+    const error = new Error("forbidden");
+    error.name = "ForbiddenError";
+    expect(shouldRenderAdminForbidden(error)).toBe(true);
+  });
+
+  it("returns false for other errors", () => {
+    expect(shouldRenderAdminForbidden(new Error("boom"))).toBe(false);
+  });
+});

--- a/apps/web/src/lib/admin-access.ts
+++ b/apps/web/src/lib/admin-access.ts
@@ -1,0 +1,3 @@
+export function shouldRenderAdminForbidden(error: unknown) {
+  return error instanceof Error && error.name === "ForbiddenError";
+}

--- a/apps/web/src/lib/admin-ops.test.ts
+++ b/apps/web/src/lib/admin-ops.test.ts
@@ -56,4 +56,33 @@ describe("admin ops helpers", () => {
       tone: "healthy",
     });
   });
+
+  it("marks a source healthy again after a later clean run", () => {
+    const rows = buildAdminSourceHealth(
+      [
+        {
+          success: true,
+          completedAt: new Date(),
+          sourceErrors: [],
+        },
+        {
+          success: false,
+          completedAt: new Date(Date.now() - 60_000),
+          sourceErrors: [
+            {
+              source: "official-mcp-registry",
+              error: "timeout",
+            },
+          ],
+        },
+      ],
+      [{ sourceName: "official-mcp-registry", count: 100 }],
+    );
+
+    expect(rows.find((row) => row.key === "official-mcp-registry")).toMatchObject({
+      recentFailureCount: 1,
+      lastError: "timeout",
+      tone: "healthy",
+    });
+  });
 });

--- a/apps/web/src/lib/admin-ops.ts
+++ b/apps/web/src/lib/admin-ops.ts
@@ -53,6 +53,20 @@ export function computeFailureStreak(runs: AdminOpsRunLike[]): number {
   return streak;
 }
 
+function computeSourceFailureStreak(runs: AdminOpsRunLike[], sourceKey: string): number {
+  let streak = 0;
+
+  for (const run of runs) {
+    const hasSourceError = run.sourceErrors.some((error) => error.source === sourceKey);
+    if (!hasSourceError) {
+      break;
+    }
+    streak += 1;
+  }
+
+  return streak;
+}
+
 export function classifyCatalogFreshness(
   latestCatalogSyncAt: Date | string | number | null | undefined,
   now = new Date(),
@@ -92,11 +106,12 @@ export function buildAdminSourceHealth(
     );
     const lastError = sourceErrors[0]?.error ?? null;
     const recentFailureCount = sourceErrors.length;
+    const currentFailureStreak = computeSourceFailureStreak(runs, source.key);
 
     let tone: HealthTone = "healthy";
-    if (recentFailureCount >= 3 || (itemCount === 0 && recentFailureCount > 0)) {
+    if (currentFailureStreak >= 3 || (itemCount === 0 && currentFailureStreak > 0)) {
       tone = "critical";
-    } else if (recentFailureCount > 0) {
+    } else if (currentFailureStreak > 0) {
       tone = "warning";
     }
 

--- a/packages/registry/src/index.test.ts
+++ b/packages/registry/src/index.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { RegistrySyncService } from "./index";
 import type { McpEntry } from "./schemas";
-import { stripHtml } from "./utils";
+import { removeDuplicateOfficialSkillMirrors, stripHtml } from "./utils";
 
 const tempFiles: string[] = [];
 
@@ -25,6 +25,52 @@ async function createVerifiedCatalog(contents: string) {
 }
 
 describe("RegistrySyncService", () => {
+  it("removes duplicate official skill mirrors while keeping the preferred repo", () => {
+    const deduped = removeDuplicateOfficialSkillMirrors([
+      {
+        id: "skill-a",
+        type: "skill",
+        displayName: "Context Engineering",
+        verified: false,
+        sourceName: "skills-sh-official",
+        sourceUrl: "https://www.skills.sh/acme/context-skill/context-engineering",
+        data: {
+          id: "skill-a",
+          displayName: "Context Engineering",
+          verified: false,
+          source: {
+            type: "github",
+            repo: "acme/context-skill",
+            path: "context-engineering",
+            ref: "main",
+          },
+        },
+      },
+      {
+        id: "skill-b",
+        type: "skill",
+        displayName: "Context Engineering",
+        verified: false,
+        sourceName: "skills-sh-official",
+        sourceUrl: "https://www.skills.sh/acme/context-skills/context-engineering",
+        data: {
+          id: "skill-b",
+          displayName: "Context Engineering",
+          verified: false,
+          source: {
+            type: "github",
+            repo: "acme/context-skills",
+            path: "context-engineering",
+            ref: "main",
+          },
+        },
+      },
+    ]);
+
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0]?.id).toBe("skill-a");
+  });
+
   it("strips HTML without double-unescaping ampersand-prefixed entities", () => {
     expect(stripHtml("&amp;quot;")).toBe("&quot;");
     expect(stripHtml("<p>Hello &amp; welcome</p>")).toBe("Hello & welcome");

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -22,6 +22,7 @@ import {
   canonicalSkillsShMirrorKey,
   normalizeSkillRepoFamily,
   pickPreferredSkillMirror,
+  removeDuplicateOfficialSkillMirrors,
   preferCollectedSkillMirrorCandidate,
   toResult,
 } from "./utils";
@@ -250,7 +251,9 @@ export class RegistrySyncService {
     }
 
     return {
-      items: [...passthroughItems, ...skillMirrorDeduped.values()].map((item) => item.catalogItem),
+      items: removeDuplicateOfficialSkillMirrors(
+        [...passthroughItems, ...skillMirrorDeduped.values()].map((item) => item.catalogItem),
+      ),
       errors,
       sourceRuns,
     };

--- a/packages/registry/src/utils.ts
+++ b/packages/registry/src/utils.ts
@@ -149,6 +149,60 @@ export function preferCollectedSkillMirrorCandidate(
   return preferSkillMirrorCandidate(candidate, existing);
 }
 
+export function removeDuplicateOfficialSkillMirrors(items: CatalogSeedItem[]) {
+  const grouped = new Map<string, Array<{ index: number; id: string; repo: string }>>();
+
+  for (const [index, item] of items.entries()) {
+    if (item.type !== "skill" || item.sourceName !== "skills-sh-official") {
+      continue;
+    }
+
+    const skillData = item.data as SkillEntry;
+    const source = skillData.source;
+    if (source?.type !== "github" || !source.repo || !source.path) {
+      continue;
+    }
+
+    const key = [
+      normalizeSkillRepoFamily(String(source.repo)),
+      normalizeCatalogText(String(source.path)).toLowerCase(),
+      canonicalGithubRef(source.ref),
+      normalizeCatalogText(item.displayName).toLowerCase(),
+    ].join("|");
+
+    const bucket = grouped.get(key) ?? [];
+    bucket.push({
+      index,
+      id: item.id,
+      repo: String(source.repo),
+    });
+    grouped.set(key, bucket);
+  }
+
+  const duplicateIndexes = new Set<number>();
+
+  for (const bucket of grouped.values()) {
+    if (bucket.length < 2) {
+      continue;
+    }
+
+    const preferred = bucket
+      .map((candidate) => ({ id: candidate.id, repo: candidate.repo }))
+      .reduce((best, candidate) => pickPreferredSkillMirror(best, candidate));
+    for (const candidate of bucket) {
+      if (candidate.id !== preferred.id) {
+        duplicateIndexes.add(candidate.index);
+      }
+    }
+  }
+
+  if (duplicateIndexes.size === 0) {
+    return items;
+  }
+
+  return items.filter((_, index) => !duplicateIndexes.has(index));
+}
+
 export function slugify(value: string) {
   return normalizeCatalogText(value)
     .toLowerCase()


### PR DESCRIPTION
## Summary
- add responsive custom forbidden and not-found pages with noindex metadata
- use a real 403 surface for unauthorized admin access instead of redirecting home
- fix collector-health warning logic so later clean syncs clear stale warnings
- align registry sync summary counts more closely with persisted catalog state by removing duplicate official skill mirrors before reporting

## Verification
- pnpm exec vitest run packages/registry/src/index.test.ts apps/web/src/lib/admin-ops.test.ts apps/web/src/app/admin/health-actions.test.ts apps/web/src/components/layout/StatusPage.test.tsx apps/web/src/app/not-found.test.ts apps/web/src/app/forbidden.test.ts apps/web/src/lib/admin-access.test.ts
- pnpm --filter web build