### PR TITLE
fix: restore green CI for admin status pages

### DIFF
--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -1,10 +1,10 @@
+import { shouldRenderAdminForbidden } from "@/lib/admin-access";
 import {
   type HealthTone,
   buildAdminSourceHealth,
   classifyCatalogFreshness,
   computeFailureStreak,
 } from "@/lib/admin-ops";
-import { shouldRenderAdminForbidden } from "@/lib/admin-access";
 import { requireAdminRole } from "@/lib/admin-session";
 import {
   catalogItems,

--- a/apps/web/src/components/layout/StatusPage.tsx
+++ b/apps/web/src/components/layout/StatusPage.tsx
@@ -25,9 +25,7 @@ export function StatusPage({
 }: StatusPageProps) {
   const accentClass = tone === "warning" ? "text-amber-300" : "text-accent";
   const borderClass =
-    tone === "warning"
-      ? "border-amber-400/30 bg-amber-400/10"
-      : "border-accent/30 bg-accent/10";
+    tone === "warning" ? "border-amber-400/30 bg-amber-400/10" : "border-accent/30 bg-accent/10";
   const Icon = tone === "warning" ? ShieldAlert : TriangleAlert;
 
   return (

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -22,8 +22,8 @@ import {
   canonicalSkillsShMirrorKey,
   normalizeSkillRepoFamily,
   pickPreferredSkillMirror,
-  removeDuplicateOfficialSkillMirrors,
   preferCollectedSkillMirrorCandidate,
+  removeDuplicateOfficialSkillMirrors,
   toResult,
 } from "./utils";
 


### PR DESCRIPTION
## Summary
- fix Biome import ordering in the admin page
- align status page formatting with repository style rules
- keep admin/403/404 behavior unchanged while restoring CI

## Verification
- pnpm exec biome check apps/web/src/app/admin/page.tsx apps/web/src/components/layout/StatusPage.tsx
- pnpm exec vitest run apps/web/src/components/layout/StatusPage.test.tsx apps/web/src/app/not-found.test.ts apps/web/src/app/forbidden.test.ts apps/web/src/lib/admin-access.test.ts apps/web/src/app/admin/health-actions.test.ts apps/web/src/lib/admin-ops.test.ts packages/registry/src/index.test.ts