### PR TITLE
fix: stabilize admin 403 smoke coverage

### DIFF
--- a/apps/web/e2e/flow.spec.ts
+++ b/apps/web/e2e/flow.spec.ts
@@ -143,9 +143,9 @@ test.describe("VibeBasket — Security + Docs", () => {
     }
   });
 
-  test("unauthenticated admin access falls back to the home page", async ({ page }) => {
-    await page.goto("/admin");
-    await page.waitForURL(/\/$/);
-    await expect(page).toHaveTitle(/VibeBasket/);
+  test("unauthenticated admin access renders the 403 page", async ({ page }) => {
+    const response = await page.goto("/admin");
+    expect(response?.status()).toBe(403);
+    await expect(page).toHaveURL(/\/admin$/);
   });
 });

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,6 +6,9 @@ const nextConfig: NextConfig = {
   // Required for the Docker standalone image (generates apps/web/.next/standalone/server.js)
   output: process.env.NODE_ENV === "production" ? "standalone" : undefined,
   productionBrowserSourceMaps: false,
+  experimental: {
+    authInterrupts: true,
+  },
   allowedDevOrigins: getAllowedDevOrigins(),
   serverExternalPackages: ["@libsql/client", "libsql"],
   outputFileTracingIncludes: {


### PR DESCRIPTION
## Summary
- enable Next auth interrupts for the admin forbidden flow
- align the smoke test with the actual 403 security contract
- keep the admin route denied for unauthenticated users without relying on brittle page-body assertions

## Verification
- pnpm exec biome check apps/web/e2e/flow.spec.ts apps/web/next.config.ts
- pnpm --filter web build
- pnpm --filter web test:e2e:smoke