### PR TITLE
Harden remote MCP URLs and backup auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,34 +16,32 @@ Bundle trusted MCP servers, agent skills, and project rules into one shareable i
 ## Table of Contents
 
 - [What is VibeBasket?](#what-is-vibebasket)
-- [Where It Fits](#where-it-fits)
+- [Who It's For](#who-its-for)
 - [What It Is Not](#what-it-is-not)
 - [Supported IDEs](#supported-ides-24-targets)
-- [Core Features](#core-features)
+- [Core Capabilities](#core-capabilities)
 - [Quick Start](#quick-start)
-- [Self-Hosting](#self-hosting)
 - [CLI Usage](#cli-usage)
 - [Configuration](#configuration)
+- [Self-Hosting](#self-hosting)
 - [Architecture](#architecture)
-- [Repository Docs](#repository-docs)
+- [Docs Map](#docs-map)
 - [Security](#security)
 - [License](#license)
 
 ## What is VibeBasket?
 
-Stop manually configuring MCP servers one IDE at a time. Browse a trusted catalog that syncs tens of thousands of community and official integrations, pick what you need, and generate a single `npx` command that installs everything — idempotently, with automatic backups, across every tool you use.
+VibeBasket helps you stop configuring MCP servers, skills, and rules one tool at a time.
+
+Browse a trusted catalog, select what you want, and generate one `npx` command that applies the bundle across the AI IDEs and CLI tools you actually use.
 
 ```
 npx vibebasket apply https://vibebasket.dev/api/bundle/cj2k9x
 ```
 
-The CLI is also published on npm as [`vibebasket`](https://www.npmjs.com/package/vibebasket).
+Use the hosted app at [vibebasket.dev](https://vibebasket.dev) or the published CLI package at [npmjs.com/package/vibebasket](https://www.npmjs.com/package/vibebasket).
 
-For maintainers: keep any local npm credentials in your user-level `~/.npmrc` only when you intentionally need them for a manual local publish or private registry access. The repository deliberately does not rely on a tracked project `.npmrc`.
-
-The repo is now wired for GitHub Actions-based npm publishing in [`.github/workflows/publish.yml`](.github/workflows/publish.yml). After the package is linked once in npm Trusted Publisher settings, published GitHub releases can publish with npm provenance and without a long-lived publish token. The workflow also keeps a manual `workflow_dispatch` path for maintainers who deliberately need a manual publish run.
-
-## Where It Fits
+## Who It's For
 
 - Standardizing MCP-heavy setups across multiple AI IDEs and terminal tools
 - Turning one curated stack into a repeatable install flow for a team or project
@@ -87,26 +85,25 @@ The repo is now wired for GitHub Actions-based npm publishing in [`.github/workf
 
 16 adapters auto-install Skills. 6 auto-install Rules. All MCP-capable adapters auto-install MCP servers.
 
-## Core Features
+## Core Capabilities
 
-### Catalog
+### Trusted catalog
 - Tens of thousands of items when synced from the official MCP Registry, the public skills.sh catalog, and curated sources
 - Trust tiers: Verified (curated), Official (upstream), Community — no misleading scores
 - FTS5 full-text search with prefix matching across display name, description, and source URL
-- Filter by type, trust tier, source freshness, and sort order
-- Detail view per item: install command, GitHub repo, sync freshness
+- Filter by type, trust tier, freshness, and sort order
 
-Important scope note:
+Catalog scope:
 
 - MCP coverage is intentionally bounded by the official MCP Registry plus curated verified overrides
 - Skills coverage comes from the public `skills.sh` corpus plus curated verified overrides
 - If a popular MCP is not published in the official registry, it will not appear automatically until it is curated or the upstream registry adds it
 
-Catalog freshness note:
-
-- ordinary catalog reads can trigger a background refresh when the local snapshot is stale
-- that refresh path is request-driven, not a built-in always-on scheduler
-- if you want deterministic freshness windows in production, schedule `pnpm catalog:sync` yourself
+### Install engine
+- One bundle can be applied across 24 supported targets
+- Writes are idempotent and backup-aware
+- Target capability checks prevent pretending every IDE supports the same surface
+- Secrets are resolved locally by the CLI during apply
 
 ### CLI
 - `apply` — Install bundles from URLs or local files (`--force`, `--scope`, `--dry-run`, `--no-verify`)
@@ -116,22 +113,21 @@ Catalog freshness note:
 - `init` — Scaffold a VibeBasket project
 - `rollback` — Restore from timestamped backups (run from the target project root for project-scoped configs)
 
-### Security
+### Admin and operations
+- Manual catalog sync, backup management, storage config, and release-readiness checks
+- FTS health checks, DB integrity checks, and cleanup actions
+- User overview and admin allowlist management
+
+### Security model
 - End-user runtime secrets never appear in bundle manifests and are prompted locally by the CLI; most targets then store them only in that machine's local IDE config surface
 - AES-256-GCM encrypted storage credentials
 - Sliding-window rate limiting on 8 API endpoints with Retry-After headers
 - CSP and security headers enforced in production
 - Path sanitization on all file operations
 - 4 optional OAuth providers: GitHub, Google, Apple, Microsoft Entra ID
-- GitHub Actions CI, CodeQL scanning, repo secret scanning, and Dependabot update automation
-- Explicit `NEXT_PUBLIC_*` allowlist enforcement so new public env vars require intentional review
+- GitHub Actions CI, CodeQL, gitleaks, Dependabot, and `NEXT_PUBLIC_*` allowlist enforcement
 
-### Admin
-- Catalog sync triggers, backup management (6 backends), storage config
-- FTS5 health monitoring + rebuild, DB integrity checks, force cleanup
-- User overview, admin email management
-
-### Backup & Storage
+### Backup and storage
 - 6 backends: Local, AWS S3, Cloudflare R2, DigitalOcean Spaces, Azure Blob, GCS
 - Scheduled backups with configurable intervals
 - Encrypted credentials stored in SQLite, never in environment files
@@ -158,13 +154,7 @@ cp .env.example .env
 docker compose up -d
 ```
 
-After first boot, either wait for background catalog bootstrap or run `docker compose exec web node scripts/catalog-sync.mjs`, then verify freshness at `/api/catalog/status`.
-
-Expected first-run behavior:
-
-- the app comes up before the full catalog is necessarily warm
-- the first live sync may take noticeably longer than ordinary page loads
-- `/api/catalog/status` is the quickest way to confirm counts, freshness, and latest sync outcome
+After first boot, either wait for the initial catalog bootstrap or run `docker compose exec web node scripts/catalog-sync.mjs`, then verify `/api/catalog/status`.
 
 ### Manual
 
@@ -176,28 +166,9 @@ pnpm install
 pnpm dev
 ```
 
-After first boot, either wait for background catalog bootstrap or run `pnpm catalog:sync`, then verify freshness at `/api/catalog/status`.
+After first boot, either wait for the initial catalog bootstrap or run `pnpm catalog:sync`, then verify `/api/catalog/status`.
 
 Open [http://localhost:3000](http://localhost:3000).
-
-## Self-Hosting
-
-VibeBasket is currently optimized for **single-node deployments**: one app instance, one SQLite database, and no extra state infrastructure by default.
-
-Start here:
-
-- [SELF_HOSTING.md](SELF_HOSTING.md)
-- [docs/SETUP.md](docs/SETUP.md)
-- [docs/PRODUCTION_READINESS_CHECKLIST.md](docs/PRODUCTION_READINESS_CHECKLIST.md)
-
-For the first admin account on a self-hosted instance, start with [SELF_HOSTING.md#bootstrap-the-first-admin](SELF_HOSTING.md#bootstrap-the-first-admin).
-
-Operational notes:
-
-- `/api/health` is safe for container and orchestration health checks
-- `/api/catalog/status` exposes catalog freshness and latest sync state
-- `pnpm catalog:sync:strict` is available as a pre-launch validation command
-- the main CI gate is `pnpm verify:ci`
 
 ## CLI Usage
 
@@ -228,27 +199,43 @@ npx vibebasket rollback
 
 ## Configuration
 
+Most deployments only need a small subset to get started:
+
 | Variable | Required | Description |
 |----------|:--------:|-------------|
-| `AUTH_SECRET` | Yes | Session encryption secret. Generate: `openssl rand -base64 32` |
-| `NEXTAUTH_URL` | Yes | Public deployment URL for OAuth callbacks |
-| `AUTH_TRUST_HOST` | No | Set to `true` in production when running behind a trusted proxy or CDN |
-| `AUTH_<PROVIDER>_ENABLED` | No | Must be truthy (`true`, `1`, `yes`, `on`) for a provider to appear in the login UI |
+| `AUTH_SECRET` | Yes | Session and encryption secret. Generate with `openssl rand -base64 32` |
+| `NEXTAUTH_URL` | Yes | Public deployment URL used for OAuth callbacks |
+| `AUTH_<PROVIDER>_ENABLED` | No | Enables a provider only when its credentials are also present |
 | `AUTH_GITHUB_ID/SECRET` | No | GitHub OAuth credentials |
 | `AUTH_GOOGLE_ID/SECRET` | No | Google OAuth credentials |
 | `AUTH_APPLE_ID/SECRET` | No | Apple Sign-In credentials |
 | `AUTH_MICROSOFT_ENTRA_ID_ID/SECRET` | No | Microsoft Entra ID credentials |
-| `CATALOG_REFRESH_TOKEN` | No | Required only if you want authenticated production callers to use `/api/catalog?refresh=1` |
-| `CATALOG_FETCH_RETRIES` | No | Registry sync retry count for trusted upstream fetches. Default: `2` |
-| `CATALOG_MCP_REGISTRY_TIMEOUT_MS` | No | Per-request timeout for official MCP Registry fetches. Default: `60000` |
-| `CATALOG_SKILLS_TIMEOUT_MS` | No | Per-request timeout for `skills.sh` fetches. Default: `20000` |
-| `BACKUP_STORAGE_BACKEND` | No | local, s3, r2, spaces, azure, or gcs |
-| `ADMIN_OAUTH_EMAILS` | No | Comma-separated admin emails; admin access is granted only when the signed-in account email is both allowlisted and verified |
-| `TRUST_PROXY` | No | Set to `true` only when the app is actually behind a trusted reverse proxy; proxy IP headers are ignored otherwise |
+| `ADMIN_OAUTH_EMAILS` | No | Comma-separated verified emails allowed into `/admin` |
+| `AUTH_TRUST_HOST` | No | Set to `true` behind a trusted proxy or CDN |
+| `TRUST_PROXY` | No | Set to `true` only when forwarded client IP headers are trustworthy |
+| `CATALOG_REFRESH_TOKEN` | No | Needed only for authenticated production refresh calls |
+| `BACKUP_JOB_TOKEN` | No | Token for external schedulers that call `POST /api/internal/backup` |
 
-See [`.env.example`](.env.example) for the complete list.
+See [`.env.example`](.env.example) for the complete environment surface and backup backend variables.
 
 OAuth note: provider buttons appear only when the provider is both enabled and fully configured.
+
+## Self-Hosting
+
+VibeBasket is currently optimized for **single-node deployments**: one app instance, one SQLite database, and no Redis or shared cache by default.
+
+Start here:
+
+- [SELF_HOSTING.md](SELF_HOSTING.md)
+- [docs/SETUP.md](docs/SETUP.md)
+- [docs/PRODUCTION_READINESS_CHECKLIST.md](docs/PRODUCTION_READINESS_CHECKLIST.md)
+
+Operational notes:
+
+- `/api/health` is safe for container and orchestration health checks
+- `/api/catalog/status` exposes catalog freshness and the latest sync result
+- `pnpm catalog:sync:strict` is available as a pre-launch validation command
+- the main CI gate is `pnpm verify:ci`
 
 ## Architecture
 
@@ -281,12 +268,16 @@ For more detail:
 - [docs/PROJECT_OVERVIEW.md](docs/PROJECT_OVERVIEW.md)
 - [docs/SETUP.md](docs/SETUP.md)
 
-## Repository Docs
+## Docs Map
 
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 - [SECURITY.md](SECURITY.md)
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 - [SELF_HOSTING.md](SELF_HOSTING.md)
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- [docs/PROJECT_OVERVIEW.md](docs/PROJECT_OVERVIEW.md)
+- [docs/SETUP.md](docs/SETUP.md)
+- [docs/PRODUCTION_READINESS_CHECKLIST.md](docs/PRODUCTION_READINESS_CHECKLIST.md)
 
 ## Security
 
@@ -294,7 +285,6 @@ Repository guardrails:
 
 - CI runs a repo-level secret scan with `gitleaks`.
 - Executable and config files are checked for `NEXT_PUBLIC_*` usage, and only reviewed allowlisted names are accepted.
-- local npm credentials, if you use them for a manual publish or private registry access, should stay in the user-level `~/.npmrc`, never in the repository.
 
 Report vulnerabilities via [GitHub Security Advisories](https://github.com/mhmtayberk/VibeBasket/security/advisories/new). See [SECURITY.md](SECURITY.md) for the full threat model.
 

--- a/apps/web/src/app/api/internal/backup/route.test.ts
+++ b/apps/web/src/app/api/internal/backup/route.test.ts
@@ -2,9 +2,16 @@ import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const runScheduledBackupJobMock = vi.fn();
+const checkRateLimitMock = vi.fn();
+const getClientAddressMock = vi.fn();
 
 vi.mock("@/lib/admin-backup-ops", () => ({
   runScheduledBackupJob: runScheduledBackupJobMock,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: checkRateLimitMock,
+  getClientAddress: getClientAddressMock,
 }));
 
 describe("/api/internal/backup", () => {
@@ -12,6 +19,13 @@ describe("/api/internal/backup", () => {
     vi.resetModules();
     vi.clearAllMocks();
     process.env.BACKUP_JOB_TOKEN = "backup-token";
+    getClientAddressMock.mockReturnValue("127.0.0.1");
+    checkRateLimitMock.mockReturnValue({
+      allowed: true,
+      remaining: 9,
+      resetAt: Date.now() + 60_000,
+      retryAfterSeconds: 0,
+    });
   });
 
   it("rejects requests without the backup job token", async () => {
@@ -49,5 +63,46 @@ describe("/api/internal/backup", () => {
 
     expect(response.status).toBe(200);
     expect(runScheduledBackupJobMock).toHaveBeenCalledWith({ force: true });
+  });
+
+  it("accepts a bearer token", async () => {
+    runScheduledBackupJobMock.mockResolvedValueOnce({
+      success: true,
+      triggered: true,
+      reason: "due",
+    });
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/internal/backup", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer backup-token",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runScheduledBackupJobMock).toHaveBeenCalledWith({ force: false });
+  });
+
+  it("rate limits repeated calls before auth evaluation", async () => {
+    checkRateLimitMock.mockReturnValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 60_000,
+      retryAfterSeconds: 60,
+    });
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/internal/backup", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(runScheduledBackupJobMock).not.toHaveBeenCalled();
+    expect(response.headers.get("Retry-After")).toBe("60");
   });
 });

--- a/apps/web/src/app/api/internal/backup/route.ts
+++ b/apps/web/src/app/api/internal/backup/route.ts
@@ -1,6 +1,27 @@
+import { timingSafeEqual } from "node:crypto";
 import { runScheduledBackupJob } from "@/lib/admin-backup-ops";
+import { checkRateLimit, getClientAddress } from "@/lib/rate-limit";
 import { applySecurityHeaders } from "@/lib/security-headers";
+import { createTooManyRequestsResponse } from "@/lib/security-headers";
 import { NextResponse } from "next/server";
+
+const BACKUP_JOB_RATE_LIMIT = 10;
+const BACKUP_JOB_RATE_WINDOW_MS = 60 * 1000;
+
+function constantTimeMatch(candidate: string | null | undefined, expected: string) {
+  if (!candidate) {
+    return false;
+  }
+
+  const candidateBuffer = Buffer.from(candidate, "utf8");
+  const expectedBuffer = Buffer.from(expected, "utf8");
+
+  if (candidateBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(candidateBuffer, expectedBuffer);
+}
 
 function isAuthorized(request: Request) {
   const expectedToken = process.env.BACKUP_JOB_TOKEN?.trim();
@@ -14,10 +35,21 @@ function isAuthorized(request: Request) {
     ?.replace(/^Bearer\s+/i, "")
     .trim();
 
-  return headerToken === expectedToken || bearerToken === expectedToken;
+  return (
+    constantTimeMatch(headerToken, expectedToken) || constantTimeMatch(bearerToken, expectedToken)
+  );
 }
 
 export async function POST(request: Request) {
+  const rateLimit = checkRateLimit(
+    `internal-backup:${getClientAddress(request)}`,
+    BACKUP_JOB_RATE_LIMIT,
+    BACKUP_JOB_RATE_WINDOW_MS,
+  );
+  if (!rateLimit.allowed) {
+    return createTooManyRequestsResponse(rateLimit.retryAfterSeconds);
+  }
+
   if (!isAuthorized(request)) {
     return applySecurityHeaders(
       NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 }),

--- a/apps/web/src/components/catalog/CatalogDetail.tsx
+++ b/apps/web/src/components/catalog/CatalogDetail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { isAllowedRemoteMcpUrl } from "@vibebasket/core";
 import type { BasketItem } from "@/store/basketStore";
 import { ExternalLink, Globe, X } from "lucide-react";
 
@@ -33,6 +34,7 @@ export function CatalogDetail({ item, open, onClose }: CatalogDetailProps) {
   if (!open) return null;
 
   const mcpData = item.mcpData;
+  const safeRemoteUrl = mcpData?.url && isAllowedRemoteMcpUrl(mcpData.url) ? mcpData.url : null;
   const ruleData = item.ruleData;
   const skillData = item.skillData;
   const skillSource = skillData?.source;
@@ -119,16 +121,16 @@ export function CatalogDetail({ item, open, onClose }: CatalogDetailProps) {
                     <span className="text-muted-foreground"> {mcpData.args.join(" ")}</span>
                   ) : null}
                 </div>
-                {mcpData.url && (
+                {safeRemoteUrl && (
                   <div className="mt-1">
                     <span className="text-muted-foreground">url:</span>{" "}
                     <a
-                      href={mcpData.url as string}
+                      href={safeRemoteUrl}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-accent hover:underline break-all"
                     >
-                      {mcpData.url as string}
+                      {safeRemoteUrl}
                     </a>
                   </div>
                 )}

--- a/packages/core/src/manifest.test.ts
+++ b/packages/core/src/manifest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BundleSchema, SCHEMA_VERSION } from "./manifest";
+import { BundleSchema, McpEntrySchema, SCHEMA_VERSION, isAllowedRemoteMcpUrl } from "./manifest";
 
 describe("manifest", () => {
   it("should validate a valid bundle", () => {
@@ -77,5 +77,28 @@ describe("manifest", () => {
 
     const result = BundleSchema.safeParse(bundleWithPack);
     expect(result.success).toBe(true);
+  });
+
+  it("allows only http and https remote MCP URLs", () => {
+    expect(isAllowedRemoteMcpUrl("https://example.com/mcp")).toBe(true);
+    expect(isAllowedRemoteMcpUrl("http://localhost:8080/mcp")).toBe(true);
+    expect(isAllowedRemoteMcpUrl("javascript:alert(1)")).toBe(false);
+    expect(isAllowedRemoteMcpUrl("file:///tmp/mcp")).toBe(false);
+  });
+
+  it("rejects non-http remote MCP URLs at schema level", () => {
+    const result = McpEntrySchema.safeParse({
+      id: "remote-bad",
+      displayName: "Remote Bad",
+      runtime: "remote",
+      url: "javascript:alert(1)",
+      args: [],
+      env: {},
+      headers: {},
+      requiredSecrets: [],
+      verified: false,
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
 
 export const SCHEMA_VERSION = "0.1" as const;
+const ALLOWED_REMOTE_MCP_PROTOCOLS = new Set(["http:", "https:"]);
+
+export function isAllowedRemoteMcpUrl(value: string): boolean {
+  try {
+    const protocol = new URL(value).protocol.toLowerCase();
+    return ALLOWED_REMOTE_MCP_PROTOCOLS.has(protocol);
+  } catch {
+    return false;
+  }
+}
 
 export const IdeIdSchema = z.enum([
   "cursor",
@@ -43,7 +53,13 @@ export const McpEntrySchema = z.object({
   runtime: RuntimeSchema,
   command: z.string().optional(), // e.g. "npx"
   args: z.array(z.string()).default([]),
-  url: z.string().url().optional(), // for runtime=remote
+  url: z
+    .string()
+    .url()
+    .refine(isAllowedRemoteMcpUrl, {
+      message: "Remote MCP URLs must use http or https.",
+    })
+    .optional(), // for runtime=remote
   env: z.record(z.string()).default({}), // values may contain ${secret:NAME}
   headers: z.record(z.string()).default({}), // remote MCP header values may contain ${secret:NAME}
   requiredSecrets: z.array(z.string()).default([]),

--- a/packages/registry/src/collectors/mcp-registry-collector.ts
+++ b/packages/registry/src/collectors/mcp-registry-collector.ts
@@ -136,8 +136,8 @@ export class OfficialMcpRegistryCollector implements SourceCollector {
   private normalizeRegistryServer(server: McpRegistryServer) {
     const remoteDefinition = server.remotes?.find((remote) => {
       try {
-        new URL(remote.url);
-        return true;
+        const protocol = new URL(remote.url).protocol.toLowerCase();
+        return protocol === "http:" || protocol === "https:";
       } catch {
         return false;
       }

--- a/packages/registry/src/schemas.test.ts
+++ b/packages/registry/src/schemas.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { McpEntrySchema } from "./schemas";
+
+describe("registry McpEntrySchema", () => {
+  it("accepts http and https remote MCP URLs", () => {
+    expect(
+      McpEntrySchema.safeParse({
+        id: "remote-good",
+        displayName: "Remote Good",
+        runtime: "remote",
+        url: "https://example.com/mcp",
+        args: [],
+        env: {},
+        headers: {},
+        requiredSecrets: [],
+        verified: false,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects non-http remote MCP URLs", () => {
+    expect(
+      McpEntrySchema.safeParse({
+        id: "remote-bad",
+        displayName: "Remote Bad",
+        runtime: "remote",
+        url: "javascript:alert(1)",
+        args: [],
+        env: {},
+        headers: {},
+        requiredSecrets: [],
+        verified: false,
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/registry/src/schemas.ts
+++ b/packages/registry/src/schemas.ts
@@ -3,6 +3,16 @@ import { z } from "zod";
 export type CatalogItemType = "mcp" | "skill" | "rule" | "workflow";
 
 export const RuntimeSchema = z.enum(["npx", "uvx", "docker", "remote", "node", "python"]);
+const ALLOWED_REMOTE_MCP_PROTOCOLS = new Set(["http:", "https:"]);
+
+function isAllowedRemoteMcpUrl(value: string): boolean {
+  try {
+    const protocol = new URL(value).protocol.toLowerCase();
+    return ALLOWED_REMOTE_MCP_PROTOCOLS.has(protocol);
+  } catch {
+    return false;
+  }
+}
 
 export const McpEntrySchema = z.object({
   id: z.string().regex(/^[a-z0-9-]+$/),
@@ -11,7 +21,13 @@ export const McpEntrySchema = z.object({
   runtime: RuntimeSchema,
   command: z.string().optional(),
   args: z.array(z.string()).default([]),
-  url: z.string().url().optional(),
+  url: z
+    .string()
+    .url()
+    .refine(isAllowedRemoteMcpUrl, {
+      message: "Remote MCP URLs must use http or https.",
+    })
+    .optional(),
   env: z.record(z.string()).default({}),
   headers: z.record(z.string()).default({}),
   requiredSecrets: z.array(z.string()).default([]),


### PR DESCRIPTION
## Summary
- restrict remote MCP URLs to safe http/https schemes across core, registry, and UI surfaces
- harden the internal backup trigger with rate limiting and timing-safe token comparison
- simplify README structure for a clearer public-facing first pass

## Verification
- pnpm --filter @vibebasket/core test -- src/manifest.test.ts
- pnpm --filter @vibebasket/registry test -- src/schemas.test.ts src/index.test.ts
- pnpm --filter web test -- 'src/app/api/internal/backup/route.test.ts' 'src/lib/safe-redirect.test.ts' 'src/app/api/bundle/route.test.ts' 'src/app/api/bundle/[id]/route.test.ts' 'src/app/api/catalog/route.test.ts' 'src/lib/security-headers.test.ts'
- pnpm --filter @vibebasket/adapters test -- src/mcp-utils.test.ts src/codex.test.ts src/continue.test.ts
- pnpm --filter vibebasket test -- src/apply.test.ts src/install-verification.test.ts
- pnpm --filter web typecheck
- pnpm --filter vibebasket build