### PR TITLE
fix(ci): isolate manifest import in catalog detail

### DIFF
--- a/apps/web/src/components/catalog/CatalogDetail.tsx
+++ b/apps/web/src/components/catalog/CatalogDetail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { isAllowedRemoteMcpUrl } from "@vibebasket/core";
 import type { BasketItem } from "@/store/basketStore";
+import { isAllowedRemoteMcpUrl } from "@vibebasket/core/manifest";
 import { ExternalLink, Globe, X } from "lucide-react";
 
 interface CatalogDetailProps {


### PR DESCRIPTION
## Summary
- route the catalog detail remote MCP URL check through the manifest subpath export
- avoid pulling server-only core db exports into the client bundle
- restore green CI and CodeQL web builds

## Verification
- pnpm verify:ci
- pnpm build:web
