### PR TITLE
docs(ui): clarify target counts and add self-host call-to-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Bundle trusted MCP servers, agent skills, and project rules into one shareable i
 - [What is VibeBasket?](#what-is-vibebasket)
 - [Who It's For](#who-its-for)
 - [What It Is Not](#what-it-is-not)
-- [Supported IDEs](#supported-ides-24-targets)
+- [Supported Targets](#supported-targets-24-ides--cli-tools)
 - [Core Capabilities](#core-capabilities)
 - [Quick Start](#quick-start)
 - [CLI Usage](#cli-usage)
@@ -39,7 +39,11 @@ Browse a trusted catalog, select what you want, and generate one `npx` command t
 npx vibebasket apply https://vibebasket.dev/api/bundle/cj2k9x
 ```
 
-Use the hosted app at [vibebasket.dev](https://vibebasket.dev) or the published CLI package at [npmjs.com/package/vibebasket](https://www.npmjs.com/package/vibebasket).
+Start here:
+
+- Hosted app: [vibebasket.dev](https://vibebasket.dev)
+- npm package: [npmjs.com/package/vibebasket](https://www.npmjs.com/package/vibebasket)
+- Self-host guide: [SELF_HOSTING.md](SELF_HOSTING.md)
 
 ## Who It's For
 
@@ -54,7 +58,7 @@ Use the hosted app at [vibebasket.dev](https://vibebasket.dev) or the published 
 - A multi-node control plane with shared cache/state infrastructure by default
 - A universal package manager for arbitrary IDE extensions outside MCPs, Skills, and Rules
 
-## Supported IDEs (24 Targets)
+## Supported Targets (24 IDEs & CLI tools)
 
 | IDE | MCP | Skills | Rules |
 |-----|:---:|:------:|:-----:|
@@ -83,7 +87,7 @@ Use the hosted app at [vibebasket.dev](https://vibebasket.dev) or the published 
 | CodeBuddy | ✅ | ✅ | — |
 | OpenCode | ✅ | ✅ | ✅ |
 
-16 adapters auto-install Skills. 6 auto-install Rules. All MCP-capable adapters auto-install MCP servers.
+16 supported targets auto-install Skills. 6 supported targets auto-install Rules. All MCP-capable targets auto-install MCP servers.
 
 ## Core Capabilities
 

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -343,7 +343,7 @@ export default async function DocsPage({
 
           <div className="border-t border-border/70 p-4">
             <p className="font-mono text-[9px] uppercase tracking-[0.25em] text-muted-foreground/35 mb-2 pl-2">
-              v0.9 · 24 adapters
+              v0.9 · 24 supported targets
             </p>
           </div>
         </aside>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -239,6 +239,15 @@ export default async function Home() {
                 <TerminalSquare className="h-4 w-4" />
                 View catalog
               </a>
+              <Link
+                href="https://github.com/mhmtayberk/VibeBasket/blob/main/SELF_HOSTING.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex h-11 items-center justify-center gap-2 border border-border/80 bg-card/70 px-4 font-mono text-[10px] uppercase tracking-[0.16em] text-foreground transition-colors hover:border-accent/40 hover:text-accent sm:h-12 sm:px-5 sm:text-[11px] sm:tracking-[0.18em]"
+              >
+                <ArrowUpRight className="h-4 w-4" />
+                Self-host guide
+              </Link>
             </div>
 
             <div className="mt-8 overflow-hidden border-y border-border/70 py-4 sm:mt-10">


### PR DESCRIPTION
## Summary
- clarify public README wording around supported targets vs capability counts
- surface hosted app, npm package, and self-host guide more clearly in README
- add a self-host guide CTA to the homepage hero and align docs sidebar wording

## Verification
- pnpm --filter web build
