### PR TITLE
feat(web): add manifest and generated social preview images

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -32,14 +32,12 @@ export const metadata: Metadata = {
     siteName: "VibeBasket",
     locale: "en_US",
     type: "website",
-    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image",
     title: "VibeBasket — AI Setup Bundles for MCPs, Skills, and Rules",
     description:
       "Share one install flow for trusted MCPs, skills, and rules across every AI coding tool.",
-    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
   },
   robots: {
     index: true,

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "VibeBasket",
+    short_name: "VibeBasket",
+    description:
+      "Bundle trusted MCP servers, skills, and rules into one shareable install flow for AI IDEs and CLI tools.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#0f1512",
+    theme_color: "#0f1512",
+    categories: ["developer", "productivity", "utilities"],
+    lang: "en",
+  };
+}

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -9,76 +9,74 @@ export const contentType = "image/png";
 
 export default function OpenGraphImage() {
   return new ImageResponse(
-    (
+    <div
+      style={{
+        height: "100%",
+        width: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        background: "#0f1512",
+        color: "#f4f7f5",
+        padding: "64px",
+        fontFamily:
+          'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      }}
+    >
       <div
         style={{
-          height: "100%",
-          width: "100%",
           display: "flex",
-          flexDirection: "column",
-          justifyContent: "space-between",
-          background: "#0f1512",
-          color: "#f4f7f5",
-          padding: "64px",
-          fontFamily:
-            'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+          alignItems: "center",
+          gap: "16px",
+          color: "#92f8d3",
+          fontSize: 24,
+          letterSpacing: "0.28em",
+          textTransform: "uppercase",
         }}
       >
         <div
           style={{
+            width: 12,
+            height: 12,
+            borderRadius: 9999,
+            background: "#92f8d3",
             display: "flex",
-            alignItems: "center",
-            gap: "16px",
-            color: "#92f8d3",
-            fontSize: 24,
-            letterSpacing: "0.28em",
-            textTransform: "uppercase",
           }}
-        >
-          <div
-            style={{
-              width: 12,
-              height: 12,
-              borderRadius: 9999,
-              background: "#92f8d3",
-              display: "flex",
-            }}
-          />
-          Trusted AI setup bundles
-        </div>
+        />
+        Trusted AI setup bundles
+      </div>
 
-        <div style={{ display: "flex", flexDirection: "column", gap: "28px", maxWidth: 940 }}>
-          <div style={{ fontSize: 96, fontWeight: 700, letterSpacing: "-0.05em", lineHeight: 0.92 }}>
-            VibeBasket
-          </div>
-          <div
-            style={{
-              fontSize: 36,
-              lineHeight: 1.35,
-              color: "#c2d0c9",
-              maxWidth: 920,
-            }}
-          >
-            Bundle trusted MCP servers, skills, and project rules into one shareable install flow.
-          </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "28px", maxWidth: 940 }}>
+        <div style={{ fontSize: 96, fontWeight: 700, letterSpacing: "-0.05em", lineHeight: 0.92 }}>
+          VibeBasket
         </div>
-
         <div
           style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            borderTop: "1px solid rgba(146, 248, 211, 0.2)",
-            paddingTop: 24,
-            color: "#92f8d3",
-            fontSize: 24,
+            fontSize: 36,
+            lineHeight: 1.35,
+            color: "#c2d0c9",
+            maxWidth: 920,
           }}
         >
-          <div style={{ display: "flex" }}>vibebasket.dev</div>
-          <div style={{ display: "flex", color: "#c2d0c9" }}>24 supported targets</div>
+          Bundle trusted MCP servers, skills, and project rules into one shareable install flow.
         </div>
       </div>
-    ),
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          borderTop: "1px solid rgba(146, 248, 211, 0.2)",
+          paddingTop: 24,
+          color: "#92f8d3",
+          fontSize: 24,
+        }}
+      >
+        <div style={{ display: "flex" }}>vibebasket.dev</div>
+        <div style={{ display: "flex", color: "#c2d0c9" }}>24 supported targets</div>
+      </div>
+    </div>,
     size,
   );
 }

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -1,0 +1,84 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "VibeBasket";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = "image/png";
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "#0f1512",
+          color: "#f4f7f5",
+          padding: "64px",
+          fontFamily:
+            'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "16px",
+            color: "#92f8d3",
+            fontSize: 24,
+            letterSpacing: "0.28em",
+            textTransform: "uppercase",
+          }}
+        >
+          <div
+            style={{
+              width: 12,
+              height: 12,
+              borderRadius: 9999,
+              background: "#92f8d3",
+              display: "flex",
+            }}
+          />
+          Trusted AI setup bundles
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "28px", maxWidth: 940 }}>
+          <div style={{ fontSize: 96, fontWeight: 700, letterSpacing: "-0.05em", lineHeight: 0.92 }}>
+            VibeBasket
+          </div>
+          <div
+            style={{
+              fontSize: 36,
+              lineHeight: 1.35,
+              color: "#c2d0c9",
+              maxWidth: 920,
+            }}
+          >
+            Bundle trusted MCP servers, skills, and project rules into one shareable install flow.
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderTop: "1px solid rgba(146, 248, 211, 0.2)",
+            paddingTop: 24,
+            color: "#92f8d3",
+            fontSize: 24,
+          }}
+        >
+          <div style={{ display: "flex" }}>vibebasket.dev</div>
+          <div style={{ display: "flex", color: "#c2d0c9" }}>24 supported targets</div>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/apps/web/src/app/twitter-image.tsx
+++ b/apps/web/src/app/twitter-image.tsx
@@ -1,0 +1,2 @@
+export { alt, contentType, size } from "./opengraph-image";
+export { default } from "./opengraph-image";


### PR DESCRIPTION
## Summary
- add a Next.js web manifest for the public site
- replace broken static OG/Twitter image references with generated social preview routes
- keep the existing metadata copy while removing dead image links

## Verification
- pnpm --filter web build
