### PR TITLE
docs: align self-host metadata and recovery guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ out/
 
 # Internal working docs (keep local unless intentionally published)
 memory-bank/
+memory-bank-private/
 docs/superpowers/
 docs/CODING_STANDARDS.md
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -240,6 +240,7 @@ Notes:
 - scheduled backups are supported
 - built-in local backup/restore flows assume a file-based SQLite `DATABASE_URL`
 - test at least one full restore cycle before trusting the setup operationally
+- for full VPS disaster recovery, also keep a host-level backup of your `/data` volume, deployment `.env`, and compose/runtime files; the built-in backup system protects app data, but it is not a complete server recovery plan by itself
 
 ## Kubernetes
 

--- a/apps/web/src/app/docs/tabs/DocsTabSelfHosting.tsx
+++ b/apps/web/src/app/docs/tabs/DocsTabSelfHosting.tsx
@@ -45,8 +45,8 @@ export function DocsTabSelfHosting() {
               <p className="font-mono text-[10px] uppercase tracking-widest text-[#a0fdda] mb-3">
                 Step 1 — Clone &amp; configure
               </p>
-              <pre className="bg-[#0a0f0d] p-6 border border-[#3e4944] font-mono text-xs text-[#bdc9c2] overflow-x-auto rounded-[2px] leading-relaxed">{`git clone https://github.com/vibebasket/vibebasket.git
-cd vibebasket
+              <pre className="bg-[#0a0f0d] p-6 border border-[#3e4944] font-mono text-xs text-[#bdc9c2] overflow-x-auto rounded-[2px] leading-relaxed">{`git clone https://github.com/mhmtayberk/VibeBasket.git
+cd VibeBasket
 
 # Copy the example env file and fill in your values
 cp .env.example .env`}</pre>
@@ -108,8 +108,8 @@ docker compose up -d --build`}</pre>
             </code>{" "}
             or an existing Kubernetes Secret.
           </p>
-          <pre className="bg-[#0a0f0d] p-6 border border-[#3e4944] font-mono text-xs text-[#bdc9c2] overflow-x-auto rounded-[2px] leading-relaxed">{`git clone https://github.com/vibebasket/vibebasket.git
-cd vibebasket
+          <pre className="bg-[#0a0f0d] p-6 border border-[#3e4944] font-mono text-xs text-[#bdc9c2] overflow-x-auto rounded-[2px] leading-relaxed">{`git clone https://github.com/mhmtayberk/VibeBasket.git
+cd VibeBasket
 
 helm install vibebasket ./charts/vibebasket \\
   --set env.NEXTAUTH_URL=https://vibebasket.example.com \\
@@ -134,7 +134,7 @@ helm install vibebasket ./charts/vibebasket -f my-values.yaml`}</pre>
             Requires Node.js &ge;20 and pnpm &ge;9. Suitable for VMs, bare-metal servers, or
             platforms that don&apos;t run Docker.
           </p>
-          <pre className="bg-[#0a0f0d] p-6 border border-[#3e4944] font-mono text-xs text-[#bdc9c2] overflow-x-auto rounded-[2px] leading-relaxed">{`git clone https://github.com/vibebasket/vibebasket.git && cd vibebasket
+          <pre className="bg-[#0a0f0d] p-6 border border-[#3e4944] font-mono text-xs text-[#bdc9c2] overflow-x-auto rounded-[2px] leading-relaxed">{`git clone https://github.com/mhmtayberk/VibeBasket.git && cd VibeBasket
 cp .env.example .env          # fill in values (see below)
 pnpm install --frozen-lockfile
 pnpm run build

--- a/charts/vibebasket/Chart.yaml
+++ b/charts/vibebasket/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: vibebasket
 description: VibeBasket — Bundle MCP servers, skills, and rules into one shareable install flow for AI coding tools.
 type: application
-version: 0.9.0
-appVersion: "0.9.0"
+version: 0.9.4
+appVersion: "0.9.4"
 keywords:
   - mcp
   - ai
@@ -11,7 +11,7 @@ keywords:
   - developer-tools
 home: https://vibebasket.dev
 sources:
-  - https://github.com/vibebasket/vibebasket
+  - https://github.com/mhmtayberk/VibeBasket
 maintainers:
   - name: VibeBasket Team
     email: team@vibebasket.dev

--- a/docs/PRODUCTION_READINESS_CHECKLIST.md
+++ b/docs/PRODUCTION_READINESS_CHECKLIST.md
@@ -39,6 +39,7 @@ Notes:
 - [ ] SQLite backups are configured and tested
 - [ ] Backup backend selection is validated so the app is not silently falling back to local storage
 - [ ] `BACKUP_JOB_TOKEN` is set if backup scheduling is enabled
+- [ ] Host-level disaster recovery for `/data`, `.env`, and deployment files is documented and tested separately from app-level backups
 
 ## 4. Deployment Shape
 

--- a/packages/registry/src/collectors/mcp-registry-collector.ts
+++ b/packages/registry/src/collectors/mcp-registry-collector.ts
@@ -15,7 +15,7 @@ import {
 
 export const MCP_REGISTRY_BASE_URL = "https://registry.modelcontextprotocol.io/v0.1";
 const REGISTRY_SYNC_USER_AGENT =
-  "VibeBasket Registry Sync/0.1 (+https://github.com/vibebasket/vibebasket)";
+  "VibeBasket Registry Sync/0.1 (+https://github.com/mhmtayberk/VibeBasket)";
 
 export class OfficialMcpRegistryCollector implements SourceCollector {
   readonly name = "official-mcp-registry";

--- a/packages/registry/src/collectors/skills-collector.ts
+++ b/packages/registry/src/collectors/skills-collector.ts
@@ -21,7 +21,7 @@ import {
 } from "../utils";
 
 const REGISTRY_SYNC_USER_AGENT =
-  "VibeBasket Registry Sync/0.1 (+https://github.com/vibebasket/vibebasket)";
+  "VibeBasket Registry Sync/0.1 (+https://github.com/mhmtayberk/VibeBasket)";
 
 export class SkillsShCuratedCollector implements SourceCollector {
   readonly name = "skills-sh-directory";


### PR DESCRIPTION
## Summary
- align Helm metadata and self-host repo URLs with the current public repository
- tighten self-host guidance around host-level disaster recovery expectations
- keep local maintainer recovery notes private via gitignore

## Verification
- pnpm lint
- pnpm typecheck