### PR TITLE
feat(web): polish responsive home experience and add app icons

### DIFF
--- a/apps/web/src/app/apple-icon.tsx
+++ b/apps/web/src/app/apple-icon.tsx
@@ -1,0 +1,74 @@
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 180,
+  height: 180,
+};
+
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#0f1512",
+        borderRadius: 36,
+        border: "4px solid rgba(160, 253, 218, 0.28)",
+      }}
+    >
+      <div
+        style={{
+          position: "relative",
+          width: 108,
+          height: 108,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            border: "6px solid #a0fdda",
+            borderTopLeftRadius: 20,
+            borderTopRightRadius: 20,
+            borderBottomLeftRadius: 28,
+            borderBottomRightRadius: 28,
+            clipPath: "polygon(12% 30%, 88% 30%, 78% 92%, 22% 92%)",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            top: 8,
+            width: 56,
+            height: 24,
+            border: "6px solid #a0fdda",
+            borderBottom: "none",
+            borderTopLeftRadius: 24,
+            borderTopRightRadius: 24,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            top: 32,
+            fontSize: 40,
+            fontWeight: 800,
+            color: "#f2f7f4",
+            letterSpacing: 0,
+          }}
+        >
+          V
+        </div>
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -106,6 +106,7 @@
   }
   body {
     @apply bg-background text-foreground antialiased selection:bg-accent/30 selection:text-foreground;
+    overflow-x: clip;
     background-image: linear-gradient(to right, rgb(62 73 68 / 0.12) 1px, transparent 1px),
       linear-gradient(to bottom, rgb(62 73 68 / 0.12) 1px, transparent 1px),
       radial-gradient(circle at top right, rgb(160 253 218 / 0.08), transparent 28%),

--- a/apps/web/src/app/icon.tsx
+++ b/apps/web/src/app/icon.tsx
@@ -1,0 +1,73 @@
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 64,
+  height: 64,
+};
+
+export const contentType = "image/png";
+
+export default function Icon() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#0f1512",
+        border: "2px solid rgba(160, 253, 218, 0.28)",
+      }}
+    >
+      <div
+        style={{
+          position: "relative",
+          width: 38,
+          height: 38,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            border: "2.5px solid #a0fdda",
+            borderTopLeftRadius: 8,
+            borderTopRightRadius: 8,
+            borderBottomLeftRadius: 10,
+            borderBottomRightRadius: 10,
+            clipPath: "polygon(12% 30%, 88% 30%, 78% 92%, 22% 92%)",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            top: 3,
+            width: 20,
+            height: 10,
+            border: "2.5px solid #a0fdda",
+            borderBottom: "none",
+            borderTopLeftRadius: 12,
+            borderTopRightRadius: 12,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            top: 14,
+            fontSize: 14,
+            fontWeight: 700,
+            color: "#f2f7f4",
+            letterSpacing: 0,
+          }}
+        >
+          V
+        </div>
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -21,6 +21,10 @@ export const metadata: Metadata = {
     "coding automation",
   ],
   authors: [{ name: "VibeBasket Team" }],
+  icons: {
+    icon: [{ url: "/icon", type: "image/png", sizes: "64x64" }],
+    apple: [{ url: "/apple-icon", sizes: "180x180", type: "image/png" }],
+  },
   alternates: {
     canonical: "/",
   },

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -10,6 +10,18 @@ export default function manifest(): MetadataRoute.Manifest {
     display: "standalone",
     background_color: "#0f1512",
     theme_color: "#0f1512",
+    icons: [
+      {
+        src: "/icon",
+        sizes: "64x64",
+        type: "image/png",
+      },
+      {
+        src: "/apple-icon",
+        sizes: "180x180",
+        type: "image/png",
+      },
+    ],
     categories: ["developer", "productivity", "utilities"],
     lang: "en",
   };

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -205,7 +205,7 @@ export default async function Home() {
 
             <h1
               id={sectionIds.heroTitle}
-              className="mt-8 max-w-3xl text-[2.55rem] font-semibold leading-[0.98] tracking-tight text-foreground sm:text-[3.55rem] sm:tracking-[-0.05em] lg:text-[4.45rem]"
+              className="mt-8 max-w-3xl text-[2.2rem] font-semibold leading-[0.96] tracking-tight text-foreground sm:text-[3.55rem] sm:tracking-[-0.05em] lg:text-[4.45rem]"
             >
               <span className="sm:hidden">Bundle your AI dev setup. Share it with one link.</span>
               <span className="hidden sm:inline">

--- a/apps/web/src/components/basket/BasketPanel.tsx
+++ b/apps/web/src/components/basket/BasketPanel.tsx
@@ -122,7 +122,9 @@ export function BasketPanel({
     <aside
       className={cn(
         "border border-border/80 bg-card/85 backdrop-blur-sm lg:max-h-[calc(100vh-140px)] lg:overflow-y-auto custom-scrollbar",
-        variant === "desktop" ? "sticky top-24 rounded-lg" : "rounded-lg",
+        variant === "desktop"
+          ? "sticky top-24 rounded-lg"
+          : "h-[min(100vh-1.5rem,980px)] rounded-2xl sm:h-auto sm:rounded-lg",
         className,
       )}
     >
@@ -256,7 +258,7 @@ export function BasketPanel({
                 </span>
               </div>
 
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {supportedTargets.map((target) => {
                   const active = targets.includes(target.id);
                   return (
@@ -294,7 +296,7 @@ export function BasketPanel({
                   </span>
                 </div>
 
-                <div className="grid max-h-56 grid-cols-2 gap-2 overflow-y-auto pr-1">
+                <div className="grid max-h-56 grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
                   {roadmapTargets.map((target) => (
                     <button
                       key={target.id}
@@ -406,8 +408,8 @@ export function BasketPanel({
           <div className="border border-border/70 bg-background/60 p-4 font-mono text-[12px] leading-6 text-muted-foreground">
             {bundleCommand ? (
               <div className="space-y-3">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="truncate text-accent">{bundleCommand}</span>
+                <div className="flex items-start justify-between gap-3">
+                  <span className="min-w-0 break-all text-accent">{bundleCommand}</span>
                   <Copy className="h-4 w-4 shrink-0 text-foreground" />
                 </div>
                 <div className="space-y-1 text-[11px]">

--- a/apps/web/src/components/basket/FloatingBasket.tsx
+++ b/apps/web/src/components/basket/FloatingBasket.tsx
@@ -26,11 +26,11 @@ export function FloatingBasket({
 
   return (
     <>
-      <div className="fixed bottom-4 left-1/2 z-50 w-[calc(100%-1.5rem)] -translate-x-1/2 lg:hidden">
+      <div className="fixed bottom-[calc(env(safe-area-inset-bottom,0px)+0.75rem)] left-1/2 z-50 w-[calc(100%-1.5rem)] max-w-[28rem] -translate-x-1/2 lg:hidden">
         <button
           type="button"
           onClick={() => setIsOpen(true)}
-          className="flex w-full items-center justify-between border border-border/80 bg-card/95 px-4 py-3 backdrop-blur-md transition-colors hover:border-accent/50"
+          className="flex w-full items-center justify-between border border-border/80 bg-card/95 px-4 py-3 shadow-[0_12px_40px_rgba(0,0,0,0.22)] backdrop-blur-md transition-colors hover:border-accent/50"
         >
           <div className="flex items-center gap-3">
             <div className="inline-flex h-10 w-10 items-center justify-center border border-accent/60 bg-accent/10 text-accent">

--- a/apps/web/src/components/catalog/CatalogGrid.tsx
+++ b/apps/web/src/components/catalog/CatalogGrid.tsx
@@ -2,7 +2,6 @@
 
 import type { EnabledAuthProvider } from "@/auth.config";
 import { BasketPanel } from "@/components/basket/BasketPanel";
-import { MobileBasketButton } from "@/components/basket/MobileBasketButton";
 import { useDebounce } from "@/hooks/use-debounce";
 import {
   type CatalogSort,
@@ -543,12 +542,6 @@ export function CatalogGrid({
           />
         </div>
       </div>
-
-      <MobileBasketButton
-        isSignedIn={isSignedIn}
-        enabledProviders={enabledProviders}
-        userRole={userRole}
-      />
     </div>
   );
 }

--- a/apps/web/src/components/layout/TopToTopButton.tsx
+++ b/apps/web/src/components/layout/TopToTopButton.tsx
@@ -23,7 +23,7 @@ export function TopToTopButton() {
       aria-label="Back to top"
       onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
       className={cn(
-        "fixed bottom-[calc(env(safe-area-inset-bottom,0px)+6.75rem)] left-4 z-40 inline-flex h-9 w-9 items-center justify-center border border-border/80 bg-card/88 text-muted-foreground backdrop-blur-sm transition-all hover:border-accent/60 hover:text-foreground sm:bottom-5 sm:left-auto sm:right-5 sm:h-11 sm:w-11 lg:bottom-5",
+        "fixed right-4 bottom-[calc(env(safe-area-inset-bottom,0px)+5.75rem)] z-40 inline-flex h-10 w-10 items-center justify-center border border-border/80 bg-card/88 text-muted-foreground backdrop-blur-sm transition-all hover:border-accent/60 hover:text-foreground sm:bottom-5 sm:right-5 sm:h-11 sm:w-11",
         visible ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-2 opacity-0",
       )}
     >


### PR DESCRIPTION
## Summary
- remove the duplicate mobile basket trigger so basket controls stop overlapping on small screens
- rebalance the mobile basket panel, floating basket, top-to-top button, and hero sizing for cleaner phone layouts
- add generated favicon and Apple touch icon support via App Router metadata and manifest wiring

## Verification
- pnpm guard:public-env
- pnpm test:guards
- pnpm lint
- pnpm --filter web build