### PR TITLE
feat: add local MCP surface and shared target-native snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Bundle trusted MCP servers, agent skills, and project rules into one shareable i
 - [Core Capabilities](#core-capabilities)
 - [Quick Start](#quick-start)
 - [CLI Usage](#cli-usage)
+- [Local MCP](#local-mcp)
 - [Configuration](#configuration)
 - [Self-Hosting](#self-hosting)
 - [Architecture](#architecture)
@@ -117,6 +118,7 @@ Catalog scope:
 - `doctor` — Diagnose IDE configurations across all targets
 - `init` — Scaffold a VibeBasket project
 - `rollback` — Restore from timestamped backups (run from the target project root for project-scoped configs)
+- `mcp serve` — Expose a local stdio MCP server so AI IDEs can search catalog items, fetch target-native MCP config snippets, plan installs, apply bundles, inspect backups, and save local stacks without leaving the IDE
 
 ### Admin and operations
 - Manual catalog sync, backup management, storage config, and release-readiness checks
@@ -204,6 +206,9 @@ npx vibebasket init
 
 # Restore from backup
 npx vibebasket rollback
+
+# Run the local MCP server for AI IDE integrations
+npx vibebasket mcp serve
 ```
 
 Example local bundle file:
@@ -220,6 +225,31 @@ Example local bundle file:
   "workflowPacks": []
 }
 ```
+
+## Local MCP
+
+VibeBasket also exposes a local stdio MCP server through the published CLI:
+
+```bash
+npx vibebasket mcp serve
+```
+
+Current phase-1 MCP capabilities:
+
+- search the hosted or self-hosted catalog
+- fetch one catalog item by id
+- inspect supported targets and target setup guidance
+- return target-native MCP config snippets so IDE agents can wire VibeBasket MCP without guessing each client's config shape
+- dry-run install plans before writes
+- apply bundles through the real adapter pipeline
+- list backups and restore them
+- save and reload local stacks on the same machine
+
+The hosted docs hub mirrors this surface with target-selectable native snippet previews so users can inspect representative JSON, YAML, and TOML merge fragments before wiring the local server into an IDE.
+
+Current non-goal in this phase:
+
+- cloud/profile-backed stack save is not linked inside local MCP yet; use the website for that path
 
 When the target adapter detects that the generated MCP config is identical to the current on-disk config, `vibebasket apply` reports a no-op for that target and does not create a redundant backup snapshot.
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -25,7 +25,31 @@ npx vibebasket search postgresql
 npx vibebasket doctor
 npx vibebasket init
 npx vibebasket rollback
+npx vibebasket mcp serve
 ```
+
+## Local MCP Server
+
+Run VibeBasket as a local stdio MCP server for AI IDEs:
+
+```bash
+npx vibebasket mcp serve
+```
+
+What the MCP surface can do today:
+
+- search catalog items
+- fetch one item by id
+- inspect supported targets and target setup guidance
+- return target-native MCP config snippets so IDE agents do not have to guess each client's config shape
+- plan installs before writing
+- apply bundles through the normal adapter pipeline
+- list or restore backups
+- save and load local stacks on the same machine
+
+Current limitation:
+
+- cloud/profile-backed stack save is not linked in the local MCP yet, so use the VibeBasket website for that path
 
 ## How Secrets Work
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -28,10 +28,12 @@
   "keywords": ["vibebasket", "mcp", "ai-ide", "cli"],
   "license": "MIT",
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@inquirer/prompts": "^8.5.2",
     "chalk": "^5.6.2",
     "commander": "^15.0.0",
-    "dotenv": "^17.4.2"
+    "dotenv": "^17.4.2",
+    "zod": "^3.25.76"
   },
   "optionalDependencies": {
     "keytar": "^7.9.0"

--- a/apps/cli/src/apply.ts
+++ b/apps/cli/src/apply.ts
@@ -1,204 +1,26 @@
-import fs from "node:fs";
-import { confirm } from "@inquirer/prompts";
-import type { IdeAdapter } from "@vibebasket/adapters";
-import {
-  AiderAdapter,
-  AntigravityAdapter,
-  ClaudeCodeAdapter,
-  ClineCliAdapter,
-  CodeBuddyAdapter,
-  CodexAdapter,
-  ContinueAdapter,
-  CortexCodeAdapter,
-  CursorAdapter,
-  DeepSeekTuiAdapter,
-  GeminiCliAdapter,
-  GitHubCopilotAdapter,
-  GooseAdapter,
-  HermesAdapter,
-  IBMBobAdapter,
-  JunieAdapter,
-  KiroAdapter,
-  OpenClawAdapter,
-  OpenCodeAdapter,
-  RooCodeAdapter,
-  VSCodeAdapter,
-  VoidAdapter,
-  WindsurfAdapter,
-  ZedAdapter,
-} from "@vibebasket/adapters";
-import type { ManagedContentApplyOutcome, ManagedContentApplyResult } from "@vibebasket/adapters";
 import chalk from "chalk";
-import { BundleSchema } from "../../../packages/core/src/manifest.js";
-import type { Bundle, IdeId, Scope } from "../../../packages/core/src/manifest.js";
-import {
-  buildTargetMcpApplyPlan,
-  flattenBundleContent,
-  getUnsupportedTargetContent,
-} from "./apply-helpers.js";
-import { createBackup } from "./backup.js";
-import { toErrorMessage } from "./errors.js";
-import { formatVerificationSummary, verifyTargetInstall } from "./install-verification.js";
-import { resolveSecrets } from "./secrets.js";
-import { applyWorkflowFiles } from "./workflow-files.js";
-
-const ADAPTERS = {
-  cursor: new CursorAdapter(),
-  antigravity: new AntigravityAdapter(),
-  windsurf: new WindsurfAdapter(),
-  vscode: new VSCodeAdapter(),
-  "claude-code": new ClaudeCodeAdapter(),
-  "deepseek-tui": new DeepSeekTuiAdapter(),
-  "gemini-cli": new GeminiCliAdapter(),
-  kiro: new KiroAdapter(),
-  junie: new JunieAdapter(),
-  "cline-cli": new ClineCliAdapter(),
-  zed: new ZedAdapter(),
-  codex: new CodexAdapter(),
-  continue: new ContinueAdapter(),
-  roocode: new RooCodeAdapter(),
-  hermes: new HermesAdapter(),
-  openclaw: new OpenClawAdapter(),
-  "github-copilot": new GitHubCopilotAdapter(),
-  void: new VoidAdapter(),
-  aider: new AiderAdapter(),
-  "cortex-code": new CortexCodeAdapter(),
-  goose: new GooseAdapter(),
-  "ibm-bob": new IBMBobAdapter(),
-  codebuddy: new CodeBuddyAdapter(),
-  opencode: new OpenCodeAdapter(),
-} as const;
-
-function stableStringify(value: unknown): string {
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
-  }
-
-  if (value && typeof value === "object") {
-    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
-      a.localeCompare(b),
-    );
-    return `{${entries
-      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`)
-      .join(",")}}`;
-  }
-
-  return JSON.stringify(value);
-}
-
-function getAdapter(targetId: IdeId): IdeAdapter | undefined {
-  return ADAPTERS[targetId as keyof typeof ADAPTERS];
-}
-
-function logManagedContentSummary(
-  adapterName: string,
-  label: "skills" | "rules",
-  result: ManagedContentApplyOutcome,
-) {
-  if (!result) {
-    console.log(chalk.gray(`  - Successfully applied ${label} for ${adapterName}`));
-    return;
-  }
-
-  const details: string[] = [];
-  if (result.written.length > 0) details.push(`${result.written.length} written`);
-  if (result.updated.length > 0) details.push(`${result.updated.length} updated`);
-  if (result.unchanged.length > 0) details.push(`${result.unchanged.length} unchanged`);
-  if (result.skipped.length > 0) details.push(`${result.skipped.length} skipped`);
-
-  console.log(
-    chalk.gray(
-      `  - Applied ${label} for ${adapterName}${details.length > 0 ? ` (${details.join(", ")})` : ""}`,
-    ),
-  );
-
-  for (const skipped of result.skipped) {
-    console.log(chalk.yellow(`    Skipped ${skipped.path}: ${skipped.reason}`));
-  }
-}
+import type { Scope } from "../../../packages/core/src/manifest.js";
+import { executeBundleApply } from "./services/apply-service.js";
+import { loadBundleFromInput } from "./services/bundle-service.js";
 
 export async function applyBundle(
   input: string,
   options: { scope?: string; force?: boolean; dryRun?: boolean; verify?: boolean },
 ) {
-  let manifest: unknown;
-
-  if (input.startsWith("http")) {
-    const res = await fetch(input);
-    if (!res.ok) throw new Error(`Failed to fetch bundle: ${res.statusText}`);
-    manifest = await res.json();
-  } else {
-    const content = fs.readFileSync(input, "utf-8");
-    manifest = JSON.parse(content);
-  }
-
-  const bundle = BundleSchema.parse(manifest);
+  const bundle = await loadBundleFromInput(input);
   const scope = (options.scope || bundle.scope) as Scope;
   const projectRoot = scope === "project" ? process.cwd() : undefined;
-  const flattened = flattenBundleContent(bundle);
 
   console.log(chalk.bold("\n📦 Bundle Summary:"));
-  console.log(`- MCP Servers: ${flattened.mcps.length}`);
-  console.log(`- Skills: ${flattened.skills.length}`);
-  console.log(`- Rules: ${flattened.rules.length}`);
-  console.log(`- Workflow Files: ${flattened.files.length}`);
+  console.log(`- MCP Servers: ${bundle.mcps.length + bundle.workflowPacks.flatMap((entry) => entry.mcps).length}`);
+  console.log(`- Skills: ${bundle.skills.length + bundle.workflowPacks.flatMap((entry) => entry.skills).length}`);
+  console.log(`- Rules: ${bundle.rules.length + bundle.workflowPacks.flatMap((entry) => entry.rules).length}`);
+  console.log(`- Workflow Files: ${bundle.workflowPacks.flatMap((entry) => entry.files).length}`);
   console.log(`- Targets: ${bundle.targets.join(", ")}`);
   console.log(`- Scope: ${scope}\n`);
 
-  const unsupportedTargets = bundle.targets.filter((targetId) => !getAdapter(targetId));
-  if (unsupportedTargets.length > 0) {
-    throw new Error(
-      `This bundle references targets the current apply engine cannot install yet: ${unsupportedTargets.join(", ")}.`,
-    );
-  }
-
-  const scopeUnsupportedTargets = bundle.targets.filter((targetId) => {
-    const adapter = getAdapter(targetId);
-    return adapter ? !adapter.supportedScopes.includes(scope) : false;
-  });
-  if (scopeUnsupportedTargets.length > 0) {
-    throw new Error(
-      `This bundle cannot be applied at ${scope} scope for: ${scopeUnsupportedTargets.join(", ")}.`,
-    );
-  }
-
-  const unsupportedFeatureMessages: string[] = [];
-  const mcpPlans = new Map<IdeId, ReturnType<typeof buildTargetMcpApplyPlan>>();
-  for (const targetId of bundle.targets) {
-    const adapter = getAdapter(targetId);
-    if (!adapter) continue;
-
-    const mcpPlan = buildTargetMcpApplyPlan(targetId, adapter, flattened.mcps);
-    mcpPlans.set(targetId, mcpPlan);
-
-    const unsupportedFeatures = getUnsupportedTargetContent(adapter, flattened);
-
-    if (unsupportedFeatures.length > 0) {
-      unsupportedFeatureMessages.push(`${adapter.displayName}: ${unsupportedFeatures.join(", ")}`);
-    }
-
-    if (mcpPlan.skipped.length > 0) {
-      unsupportedFeatureMessages.push(
-        `${adapter.displayName}: skipped MCPs -> ${mcpPlan.skipped
-          .map((item) => `${item.displayName} (${item.reason})`)
-          .join(", ")}`,
-      );
-    }
-  }
-
-  if (unsupportedFeatureMessages.length > 0) {
-    console.log(chalk.yellow("⚠️  Some targets don't support all bundle content:"));
-    for (const msg of unsupportedFeatureMessages) {
-      console.log(chalk.yellow(`   ${msg}`));
-    }
-    console.log(
-      chalk.gray(
-        "   Each target only receives the MCPs, skills, rules, and files it actually supports.\n",
-      ),
-    );
-  }
-
   if (!options.force) {
+    const { confirm } = await import("@inquirer/prompts");
     const ok = await confirm({
       message: "Do you trust this bundle and want to apply it?",
       default: true,
@@ -208,152 +30,69 @@ export async function applyBundle(
       return;
     }
   }
+  const result = await executeBundleApply(bundle, {
+    scope,
+    force: options.force ?? false,
+    dryRun: options.dryRun ?? false,
+    verify: options.verify !== false,
+    projectRoot,
+    interactiveSecrets: true,
+    logger: {
+      info(message) {
+        console.log(chalk.gray(message));
+      },
+      warn(message) {
+        console.log(chalk.yellow(message));
+      },
+      error(message) {
+        console.error(chalk.red(message));
+      },
+    },
+  });
 
-  const allRequiredSecrets = Array.from(
-    new Set(Array.from(mcpPlans.values()).flatMap((plan) => plan.requiredSecrets)),
-  );
-  const secrets = await resolveSecrets(allRequiredSecrets);
-  const failedTargets: string[] = [];
-  const skippedTargets: Array<{ targetId: IdeId; reason: string }> = [];
+  if (result.unsupportedFeatureMessages.length > 0) {
+    console.log(chalk.yellow("⚠️  Some targets don't support all bundle content:"));
+    for (const message of result.unsupportedFeatureMessages) {
+      console.log(chalk.yellow(`   ${message}`));
+    }
+    console.log(
+      chalk.gray(
+        "   Each target only receives the MCPs, skills, rules, and files it actually supports.\n",
+      ),
+    );
+  }
 
-  if (flattened.files.length > 0) {
-    if (scope !== "project" || !projectRoot) {
-      console.log(
-        chalk.yellow(
-          "⚠️  Workflow files were included, but file scaffolds only apply in project scope. Skipping workflow files.",
-        ),
-      );
-    } else if (options.dryRun) {
-      console.log(
-        chalk.gray(
-          `Dry run: would apply ${flattened.files.length} workflow file(s) under ${projectRoot}.`,
-        ),
-      );
-    } else {
-      const workflowResult = await applyWorkflowFiles(flattened.files, projectRoot);
-      if (workflowResult.written.length > 0) {
-        console.log(
-          chalk.gray(
-            `Applied workflow files: ${workflowResult.written.map((item) => item).join(", ")}`,
-          ),
-        );
-      }
-      for (const skipped of workflowResult.skipped) {
-        console.log(chalk.yellow(`Skipped workflow file ${skipped.path}: ${skipped.reason}`));
-      }
+  if (result.workflowFilesApplied.length > 0) {
+    console.log(chalk.gray(`Applied workflow files: ${result.workflowFilesApplied.join(", ")}`));
+  }
+  for (const skipped of result.workflowFilesSkipped) {
+    console.log(chalk.yellow(`Skipped workflow file ${skipped.path}: ${skipped.reason}`));
+  }
+
+  for (const targetResult of result.targetResults) {
+    console.log(chalk.blue(`\nApplying to ${targetResult.displayName}...`));
+    if (!targetResult.applied) {
+      console.log(chalk.gray(`  - Skipped: ${targetResult.skippedReason}`));
+      continue;
+    }
+    if (targetResult.backupPath) {
+      console.log(chalk.gray(`  - Created backup: ${targetResult.backupPath}`));
+    }
+    if (targetResult.verificationSummary) {
+      console.log(chalk.gray(`  - Verified install: ${targetResult.verificationSummary}`));
+    }
+    console.log(chalk.green(`✅ Successfully applied to ${targetResult.displayName}`));
+    if (targetResult.postInstallHint) {
+      console.log(chalk.cyan(`💡 ${targetResult.postInstallHint}`));
     }
   }
 
-  for (const targetId of bundle.targets) {
-    const adapter = getAdapter(targetId);
-    if (!adapter) continue;
-    const mcpPlan = mcpPlans.get(targetId);
-    if (!mcpPlan) continue;
-
-    console.log(chalk.blue(`\nApplying to ${adapter.displayName}...`));
-
-    try {
-      const shouldApplyMcps = adapter.supportsMcp && mcpPlan.supported.length > 0;
-      const shouldApplyRules =
-        adapter.supportsRules && Boolean(adapter.applyRules) && flattened.rules.length > 0;
-      const shouldApplySkills =
-        adapter.supportsSkills && Boolean(adapter.applySkills) && flattened.skills.length > 0;
-
-      if (!shouldApplyMcps && !shouldApplyRules && !shouldApplySkills) {
-        const skipReason =
-          mcpPlan.skipped.length > 0
-            ? mcpPlan.skipped.map((item) => `${item.displayName} (${item.reason})`).join(", ")
-            : `no compatible content for ${adapter.displayName}`;
-        skippedTargets.push({ targetId, reason: skipReason });
-        console.log(chalk.gray(`  - Skipped: ${skipReason}`));
-        continue;
-      }
-
-      if (mcpPlan.credentialNotice) {
-        console.log(chalk.gray(`  - ${mcpPlan.credentialNotice}`));
-      }
-
-      if (options.dryRun) {
-        if (shouldApplyMcps) {
-          const config = await adapter.readConfig(scope, projectRoot);
-          const pendingConfig = adapter.applyMcps(config, mcpPlan.supported, secrets, {
-            force: options.force || false,
-          });
-          const diff = await adapter.diff(scope, pendingConfig, projectRoot);
-          console.log(chalk.gray(`Dry run diff for ${targetId}:\n${diff}`));
-        } else {
-          console.log(
-            chalk.gray(
-              `Dry run: ${adapter.displayName} would only receive supported non-MCP content.`,
-            ),
-          );
-        }
-      } else {
-        if (shouldApplyMcps) {
-          const config = await adapter.readConfig(scope, projectRoot);
-          const pendingConfig = adapter.applyMcps(config, mcpPlan.supported, secrets, {
-            force: options.force || false,
-          });
-          if (stableStringify(config) === stableStringify(pendingConfig)) {
-            console.log(
-              chalk.gray(
-                "  - No MCP config changes detected; skipped backup creation and config write.",
-              ),
-            );
-          } else {
-            const backupPath = await createBackup(targetId, scope, config);
-            console.log(chalk.gray(`  - Created backup: ${backupPath}`));
-
-            await adapter.writeConfig(scope, pendingConfig, projectRoot);
-          }
-        }
-
-        if (shouldApplyRules && adapter.applyRules) {
-          const ruleResult = await adapter.applyRules(flattened.rules, scope, projectRoot);
-          logManagedContentSummary(adapter.displayName, "rules", ruleResult);
-        }
-
-        if (shouldApplySkills && adapter.applySkills) {
-          const skillResult = await adapter.applySkills(flattened.skills, scope, projectRoot);
-          logManagedContentSummary(adapter.displayName, "skills", skillResult);
-        }
-
-        if (options.verify !== false) {
-          const verification = await verifyTargetInstall(targetId, adapter, scope, projectRoot, {
-            mcps: shouldApplyMcps ? mcpPlan.supported : [],
-            skills: shouldApplySkills ? flattened.skills : [],
-            rules: shouldApplyRules ? flattened.rules : [],
-          });
-
-          if (!verification.ok) {
-            throw new Error(
-              `Post-install verification failed (${formatVerificationSummary(verification)})`,
-            );
-          }
-
-          console.log(
-            chalk.gray(`  - Verified install: ${formatVerificationSummary(verification)}`),
-          );
-        }
-
-        console.log(chalk.green(`✅ Successfully applied to ${adapter.displayName}`));
-        console.log(chalk.cyan(`💡 ${adapter.postInstallHint()}`));
-      }
-    } catch (error) {
-      failedTargets.push(targetId);
-      console.error(chalk.red(`❌ Failed to apply to ${targetId}: ${toErrorMessage(error)}`));
-    }
-  }
-
-  if (failedTargets.length > 0) {
-    throw new Error(`Bundle apply was incomplete. Failed targets: ${failedTargets.join(", ")}.`);
-  }
-
-  if (skippedTargets.length > 0) {
-    console.log(chalk.yellow("\nSkipped targets:"));
-    for (const skipped of skippedTargets) {
-      console.log(chalk.yellow(`- ${skipped.targetId}: ${skipped.reason}`));
-    }
+  if (result.failedTargets.length > 0) {
+    throw new Error(
+      `Bundle apply was incomplete. Failed targets: ${result.failedTargets
+        .map((target) => target.targetId)
+        .join(", ")}.`,
+    );
   }
 
   console.log(chalk.bold.green("\n✨ VibeBasket apply complete!\n"));

--- a/apps/cli/src/doctor.ts
+++ b/apps/cli/src/doctor.ts
@@ -1,61 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
-import {
-  AiderAdapter,
-  AntigravityAdapter,
-  ClaudeCodeAdapter,
-  ClineCliAdapter,
-  CodeBuddyAdapter,
-  CodexAdapter,
-  ContinueAdapter,
-  CortexCodeAdapter,
-  CursorAdapter,
-  DeepSeekTuiAdapter,
-  GeminiCliAdapter,
-  GitHubCopilotAdapter,
-  GooseAdapter,
-  HermesAdapter,
-  IBMBobAdapter,
-  JunieAdapter,
-  KiroAdapter,
-  OpenClawAdapter,
-  OpenCodeAdapter,
-  RooCodeAdapter,
-  VSCodeAdapter,
-  VoidAdapter,
-  WindsurfAdapter,
-  ZedAdapter,
-} from "@vibebasket/adapters";
 import type { IdeAdapter } from "@vibebasket/adapters";
 import chalk from "chalk";
 import { extractConfiguredMcpIds } from "./config-inspection.js";
+import { getAllAdapters } from "./runtime/adapters.js";
 
-const ADAPTERS: [string, IdeAdapter][] = [
-  ["Cursor", new CursorAdapter()],
-  ["Windsurf", new WindsurfAdapter()],
-  ["VS Code / Cline", new VSCodeAdapter()],
-  ["Antigravity", new AntigravityAdapter()],
-  ["Claude Code", new ClaudeCodeAdapter()],
-  ["DeepSeek-TUI", new DeepSeekTuiAdapter()],
-  ["Gemini CLI", new GeminiCliAdapter()],
-  ["Kiro", new KiroAdapter()],
-  ["JetBrains Junie", new JunieAdapter()],
-  ["Cline CLI", new ClineCliAdapter()],
-  ["Zed", new ZedAdapter()],
-  ["Codex CLI", new CodexAdapter()],
-  ["Continue", new ContinueAdapter()],
-  ["Roo Code", new RooCodeAdapter()],
-  ["Hermes", new HermesAdapter()],
-  ["OpenClaw", new OpenClawAdapter()],
-  ["GitHub Copilot", new GitHubCopilotAdapter()],
-  ["Void Editor", new VoidAdapter()],
-  ["Aider", new AiderAdapter()],
-  ["Cortex Code", new CortexCodeAdapter()],
-  ["Goose", new GooseAdapter()],
-  ["IBM Bob", new IBMBobAdapter()],
-  ["CodeBuddy", new CodeBuddyAdapter()],
-  ["OpenCode", new OpenCodeAdapter()],
-];
+const ADAPTERS: [string, IdeAdapter][] = getAllAdapters().map((entry) => [
+  entry[1].displayName,
+  entry[1],
+]);
 
 export async function runDoctor() {
   console.log(chalk.cyan("🧺 VibeBasket: Running diagnostics...\n"));

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -90,4 +90,16 @@ program
     }),
   );
 
+program
+  .command("mcp")
+  .description("Run the local VibeBasket MCP server")
+  .command("serve")
+  .description("Serve VibeBasket tools over stdio for AI IDE integrations")
+  .action(() =>
+    runCommand(async () => {
+      const { serveMcp } = await import("./mcp/index.js");
+      return () => serveMcp();
+    }),
+  );
+
 program.parse();

--- a/apps/cli/src/list.ts
+++ b/apps/cli/src/list.ts
@@ -1,30 +1,4 @@
 import fs from "node:fs";
-import {
-  AiderAdapter,
-  AntigravityAdapter,
-  ClaudeCodeAdapter,
-  ClineCliAdapter,
-  CodeBuddyAdapter,
-  CodexAdapter,
-  ContinueAdapter,
-  CortexCodeAdapter,
-  CursorAdapter,
-  DeepSeekTuiAdapter,
-  GeminiCliAdapter,
-  GitHubCopilotAdapter,
-  GooseAdapter,
-  HermesAdapter,
-  IBMBobAdapter,
-  JunieAdapter,
-  KiroAdapter,
-  OpenClawAdapter,
-  OpenCodeAdapter,
-  RooCodeAdapter,
-  VSCodeAdapter,
-  VoidAdapter,
-  WindsurfAdapter,
-  ZedAdapter,
-} from "@vibebasket/adapters";
 import type { IdeAdapter } from "@vibebasket/adapters";
 import chalk from "chalk";
 import type { IdeId } from "../../../packages/core/src/manifest.js";
@@ -33,33 +7,7 @@ import {
   resolveRuleInventoryTargets,
   resolveSkillInventoryTargets,
 } from "./config-inspection.js";
-
-const ADAPTERS: Record<string, IdeAdapter> = {
-  cursor: new CursorAdapter(),
-  antigravity: new AntigravityAdapter(),
-  windsurf: new WindsurfAdapter(),
-  vscode: new VSCodeAdapter(),
-  "claude-code": new ClaudeCodeAdapter(),
-  "deepseek-tui": new DeepSeekTuiAdapter(),
-  "gemini-cli": new GeminiCliAdapter(),
-  kiro: new KiroAdapter(),
-  junie: new JunieAdapter(),
-  "cline-cli": new ClineCliAdapter(),
-  zed: new ZedAdapter(),
-  codex: new CodexAdapter(),
-  continue: new ContinueAdapter(),
-  roocode: new RooCodeAdapter(),
-  hermes: new HermesAdapter(),
-  openclaw: new OpenClawAdapter(),
-  "github-copilot": new GitHubCopilotAdapter(),
-  void: new VoidAdapter(),
-  aider: new AiderAdapter(),
-  "cortex-code": new CortexCodeAdapter(),
-  goose: new GooseAdapter(),
-  "ibm-bob": new IBMBobAdapter(),
-  codebuddy: new CodeBuddyAdapter(),
-  opencode: new OpenCodeAdapter(),
-};
+import { getAllAdapters } from "./runtime/adapters.js";
 
 function fileExists(filePath: string): boolean {
   try {
@@ -114,7 +62,7 @@ export async function runList() {
   console.log(chalk.bold("\n📋 Installed IDE Configurations\n"));
   const projectRoot = process.cwd();
 
-  for (const [targetId, adapter] of Object.entries(ADAPTERS)) {
+  for (const [targetId, adapter] of getAllAdapters()) {
     let hasContent = false;
     const lines: string[] = [];
     lines.push(chalk.bold.cyan(`${adapter.displayName} (${targetId})`));

--- a/apps/cli/src/mcp/index.ts
+++ b/apps/cli/src/mcp/index.ts
@@ -1,0 +1,5 @@
+import { serveVibeBasketMcp } from "./server.js";
+
+export async function serveMcp() {
+  await serveVibeBasketMcp();
+}

--- a/apps/cli/src/mcp/policy.ts
+++ b/apps/cli/src/mcp/policy.ts
@@ -1,0 +1,71 @@
+import type { ServerNotification, ServerRequest } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type { WritePolicyMode } from "./types.js";
+
+export type ToolRiskLevel = "low" | "medium" | "high";
+
+const ConfirmationResponseSchema = z.object({
+  approved: z.boolean(),
+});
+
+export function getWritePolicyMode(): WritePolicyMode {
+  const mode = process.env.VIBEBASKET_MCP_WRITE_POLICY?.trim().toLowerCase();
+  if (mode === "allow" || mode === "deny" || mode === "confirm") {
+    return mode;
+  }
+  return "confirm";
+}
+
+export async function enforceToolPolicy(
+  risk: ToolRiskLevel,
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+  actionLabel: string,
+): Promise<{ allowed: boolean; reason?: string }> {
+  const mode = getWritePolicyMode();
+  if (risk === "low") {
+    return { allowed: true };
+  }
+
+  if (mode === "deny") {
+    return { allowed: false, reason: "Write policy is set to deny." };
+  }
+
+  if (mode === "allow") {
+    return { allowed: true };
+  }
+
+  try {
+    const result = await extra.sendRequest({
+      method: "elicitation/create",
+      params: {
+        message: `Approve VibeBasket action: ${actionLabel}`,
+        requestedSchema: {
+          type: "object",
+          properties: {
+            approved: {
+              type: "boolean",
+              title: "Approve",
+              description: `Allow VibeBasket MCP to ${actionLabel}.`,
+            },
+          },
+          required: ["approved"],
+        },
+      },
+    });
+    const parsed = ConfirmationResponseSchema.safeParse(
+      result && typeof result === "object" && "content" in result ? (result as { content?: unknown }).content : result,
+    );
+    if (parsed.success && parsed.data.approved) {
+      return { allowed: true };
+    }
+  } catch {
+    return {
+      allowed: false,
+      reason:
+        "Client confirmation is unavailable. Set VIBEBASKET_MCP_WRITE_POLICY=allow after reviewing the requested action if you want write tools enabled.",
+    };
+  }
+
+  return { allowed: false, reason: "User declined the action." };
+}

--- a/apps/cli/src/mcp/server.ts
+++ b/apps/cli/src/mcp/server.ts
@@ -1,0 +1,435 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { IdeIdSchema, ScopeSchema } from "../../../../packages/core/src/manifest.js";
+import { enforceToolPolicy } from "./policy.js";
+import { VibebasketMcpServices } from "./services.js";
+import { SelectionInputSchema, type McpToolEnvelope } from "./types.js";
+import { restoreBackupByPath } from "../services/rollback-service.js";
+
+function toolText<T extends Record<string, unknown>>(payload: McpToolEnvelope<T>): CallToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    structuredContent: payload,
+    isError: !payload.ok,
+  };
+}
+
+function success<T extends Record<string, unknown>>(
+  data: T,
+  warnings: string[] = [],
+  nextStepHint?: string,
+): McpToolEnvelope<T> {
+  return { ok: true, data, warnings, ...(nextStepHint ? { nextStepHint } : {}) };
+}
+
+function failure<T extends Record<string, unknown>>(
+  errorCode: string,
+  message: string,
+  data: T,
+  nextStepHint?: string,
+): McpToolEnvelope<T> {
+  return {
+    ok: false,
+    data,
+    warnings: [message],
+    errorCode,
+    ...(nextStepHint ? { nextStepHint } : {}),
+  };
+}
+
+const SearchInputSchema = z.object({
+  query: z.string().trim().min(1).max(120),
+  type: z.enum(["mcp", "skill", "rule", "workflow"]).optional(),
+  trust: z.enum(["all", "verified", "official", "community"]).optional(),
+  freshness: z.enum(["all", "fresh", "recent", "aging"]).optional(),
+  sort: z.enum(["recommended", "freshest", "name"]).optional(),
+  page: z.number().int().min(1).optional(),
+  limit: z.number().int().min(1).max(50).optional(),
+});
+
+const GetItemInputSchema = z.object({
+  id: z.string().trim().min(1),
+});
+
+const InstallApplyInputSchema = z
+  .object({
+    bundleUrl: z.string().url().optional(),
+    selection: SelectionInputSchema.optional(),
+    force: z.boolean().optional(),
+  })
+  .refine((value) => Boolean(value.bundleUrl || value.selection), {
+    message: "Provide either bundleUrl or selection.",
+  });
+
+const LocalStackLoadSchema = z.object({
+  stackId: z.string().trim().regex(/^[a-z0-9-]+$/),
+});
+
+const SaveLocalStackSchema = SelectionInputSchema.extend({
+  name: z.string().trim().min(1).max(80),
+});
+
+const TargetSetupGuideSchema = z.object({
+  targetId: IdeIdSchema,
+  scope: ScopeSchema.optional(),
+});
+
+const TargetMcpSnippetSchema = z.object({
+  targetId: IdeIdSchema,
+  scope: ScopeSchema.optional(),
+});
+
+export async function createVibeBasketMcpServer() {
+  const services = new VibebasketMcpServices();
+  const server = new McpServer(
+    { name: "vibebasket-local", version: "0.1.0" },
+    {
+      instructions:
+        "Use targets.list, targets.get_setup_guide, and targets.get_mcp_snippet to understand target capabilities and native config shapes. Use catalog.search before install planning. Prefer install.plan before install.apply. Cloud stack save is not linked yet in local MCP; use local stacks unless session state says otherwise.",
+    },
+  );
+
+  server.registerTool(
+    "session.get_state",
+    {
+      description: "Report the current VibeBasket MCP session capabilities and local state.",
+      inputSchema: z.object({}),
+    },
+    async () => toolText(success(await services.getSessionState())),
+  );
+
+  server.registerTool(
+    "targets.list",
+    {
+      description: "List the supported VibeBasket install targets and their capabilities.",
+      inputSchema: z.object({}),
+    },
+    async () =>
+      toolText(
+        success(
+          { targets: services.listTargets() },
+          [],
+          "Choose a targetId and call targets.get_setup_guide when you need the MCP integration details for one client.",
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "targets.get_setup_guide",
+    {
+      description:
+        "Explain how to connect the local VibeBasket MCP server or install surface for a specific target and scope.",
+      inputSchema: TargetSetupGuideSchema,
+    },
+    async ({ targetId, scope }) =>
+      toolText(
+        success(
+          { guide: services.getTargetSetupGuide(targetId, scope) },
+          [],
+          "After the target is connected, call session.get_state and then use catalog.search or install.plan.",
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "targets.get_mcp_snippet",
+    {
+      description:
+        "Return the native MCP config fragment for one target and scope so the client can wire VibeBasket MCP without guessing the config shape.",
+      inputSchema: TargetMcpSnippetSchema,
+    },
+    async ({ targetId, scope }) =>
+      toolText(
+        success(
+          { snippet: services.getTargetMcpSnippet(targetId, scope) },
+          [],
+          "Merge the returned fragment into the target's existing config, then restart that client and call session.get_state.",
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "catalog.search",
+    {
+      description: "Search the VibeBasket catalog for MCPs, skills, rules, and workflows.",
+      inputSchema: SearchInputSchema,
+    },
+    async (args) => {
+      const result = await services.catalog.search(args);
+      return toolText(
+        success(
+          result,
+          [],
+          result.items.length > 0
+            ? "Choose the item IDs you want, then call install.plan with targetIds and scope."
+            : undefined,
+        ),
+      );
+    },
+  );
+
+  server.registerTool(
+    "catalog.get_item",
+    {
+      description: "Fetch one catalog item by ID.",
+      inputSchema: GetItemInputSchema,
+    },
+    async ({ id }) => {
+      const item = await services.catalog.getItem(id);
+      if (!item) {
+        return toolText(
+          failure(
+            "not_found",
+            `Catalog item ${id} was not found.`,
+            { id },
+            "Search the catalog again to discover the current item IDs.",
+          ),
+        );
+      }
+      return toolText(success({ item }));
+    },
+  );
+
+  server.registerTool(
+    "catalog.refresh",
+    {
+      description: "Refresh the MCP session's cached view of the VibeBasket catalog with cooldown protection.",
+      inputSchema: z.object({}),
+    },
+    async (_args, extra) => {
+      const policy = await enforceToolPolicy("medium", extra, "refresh the local catalog cache");
+      if (!policy.allowed) {
+        return toolText(
+          failure("policy_blocked", policy.reason ?? "Refresh blocked.", {}, policy.reason),
+        );
+      }
+
+      try {
+        const result = await services.catalog.refresh();
+        if (!result.refreshed) {
+          return toolText(
+            failure(
+              "cooldown_active",
+              `Refresh cooldown active for ${result.cooldownMsRemaining}ms.`,
+              result,
+              "Wait for the cooldown to expire before requesting another refresh.",
+            ),
+          );
+        }
+        return toolText(success(result));
+      } catch (error) {
+        return toolText(
+          failure(
+            "network_unavailable",
+            error instanceof Error ? error.message : String(error),
+            {},
+            "Check network access or the configured VibeBasket API base URL.",
+          ),
+        );
+      }
+    },
+  );
+
+  server.registerTool(
+    "stack.list",
+    {
+      description: "List locally saved VibeBasket stacks available to this machine.",
+      inputSchema: z.object({}),
+    },
+    async () => toolText(success({ stacks: await services.listLocalStacks() })),
+  );
+
+  server.registerTool(
+    "stack.save_local",
+    {
+      description: "Save the current selection as a local reusable VibeBasket stack on this machine.",
+      inputSchema: SaveLocalStackSchema,
+    },
+    async (args, extra) => {
+      const policy = await enforceToolPolicy("medium", extra, "save a local VibeBasket stack");
+      if (!policy.allowed) {
+        return toolText(failure("policy_blocked", policy.reason ?? "Save blocked.", {}, policy.reason));
+      }
+
+      const stack = await services.saveLocalStack(args);
+      return toolText(
+        success(
+          { stack },
+          [],
+          "You can call stack.load later with this stackId or continue to install.plan.",
+        ),
+      );
+    },
+  );
+
+  server.registerTool(
+    "stack.save_cloud",
+    {
+      description: "Attempt to save a stack to the authenticated VibeBasket profile. Phase 1 reports availability and guidance only.",
+      inputSchema: SaveLocalStackSchema,
+    },
+    async () =>
+      toolText(
+        failure(
+          "auth_required",
+          "Cloud stack save is not linked in the local MCP yet.",
+          { available: false },
+          "Use stack.save_local inside the IDE today, or save profile-backed stacks on the VibeBasket website.",
+        ),
+      ),
+  );
+
+  server.registerTool(
+    "stack.load",
+    {
+      description: "Load a locally saved VibeBasket stack by ID.",
+      inputSchema: LocalStackLoadSchema,
+    },
+    async ({ stackId }) => {
+      const stack = await services.loadLocalStack(stackId);
+      if (!stack) {
+        return toolText(
+          failure("not_found", `Local stack ${stackId} was not found.`, { stackId }),
+        );
+      }
+      return toolText(
+        success(
+          { stack },
+          [],
+          "Use this stack's itemIds and targetIds with install.plan or install.apply.",
+        ),
+      );
+    },
+  );
+
+  server.registerTool(
+    "install.plan",
+    {
+      description: "Dry-run a VibeBasket installation plan for selected catalog items and targets.",
+      inputSchema: SelectionInputSchema,
+    },
+    async (args) => {
+      try {
+        const planned = await services.planInstall(args);
+        return toolText(
+          success(
+            planned,
+            planned.result.unsupportedFeatureMessages,
+            "If the plan looks right, call install.apply with the same selection or the returned bundleUrl.",
+          ),
+        );
+      } catch (error) {
+        return toolText(
+          failure(
+            "planning_failed",
+            error instanceof Error ? error.message : String(error),
+            {},
+            "Check the selected item IDs, targets, and network availability.",
+          ),
+        );
+      }
+    },
+  );
+
+  server.registerTool(
+    "install.apply",
+    {
+      description: "Apply a VibeBasket bundle or selection to the supported local AI IDE targets.",
+      inputSchema: InstallApplyInputSchema,
+    },
+    async (args, extra) => {
+      const policy = await enforceToolPolicy("high", extra, "apply configuration changes to local AI IDEs");
+      if (!policy.allowed) {
+        return toolText(failure("policy_blocked", policy.reason ?? "Apply blocked.", {}, policy.reason));
+      }
+
+      try {
+        const result = await services.applyInstall(args);
+        if (result.failedTargets.length > 0) {
+          return toolText(
+            failure(
+              "apply_failed",
+              `Apply completed with failures: ${result.failedTargets.map((target) => target.targetId).join(", ")}`,
+              result,
+              "Review the failed target errors and use install.list_backups or install.rollback if needed.",
+            ),
+          );
+        }
+
+        return toolText(
+          success(
+            result,
+            result.unsupportedFeatureMessages,
+            "If a target needs to be reverted, inspect install.list_backups and then call install.rollback.",
+          ),
+        );
+      } catch (error) {
+        return toolText(
+          failure(
+            "apply_failed",
+            error instanceof Error ? error.message : String(error),
+            {},
+            "Missing local secrets are the most common cause. Provide them in process.env, .vibebasket.env, or keychain and try again.",
+          ),
+        );
+      }
+    },
+  );
+
+  server.registerTool(
+    "install.list_backups",
+    {
+      description: "List local VibeBasket-created configuration backups available for rollback.",
+      inputSchema: z.object({}),
+    },
+    async () => toolText(success({ backups: await services.listBackups() })),
+  );
+
+  server.registerTool(
+    "install.rollback",
+    {
+      description: "Restore a previously created VibeBasket backup by backup filename path metadata.",
+      inputSchema: z.object({
+        backupPath: z.string().trim().min(1),
+      }),
+    },
+    async ({ backupPath }, extra) => {
+      const policy = await enforceToolPolicy("high", extra, "restore a previous configuration backup");
+      if (!policy.allowed) {
+        return toolText(
+          failure("policy_blocked", policy.reason ?? "Rollback blocked.", {}, policy.reason),
+        );
+      }
+
+      try {
+        const result = await restoreBackupByPath(backupPath);
+        return toolText(
+          success(
+            result,
+            [],
+            "Use install.list_backups to inspect other recovery points if needed.",
+          ),
+        );
+      } catch (error) {
+        return toolText(
+          failure(
+            "rollback_failed",
+            error instanceof Error ? error.message : String(error),
+            {},
+            "Check the backup path from install.list_backups and try again.",
+          ),
+        );
+      }
+    },
+  );
+
+  return server;
+}
+
+export async function serveVibeBasketMcp() {
+  const server = await createVibeBasketMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/apps/cli/src/mcp/services.ts
+++ b/apps/cli/src/mcp/services.ts
@@ -1,0 +1,138 @@
+import { randomUUID } from "node:crypto";
+import { CatalogApiClient } from "../services/catalog-api.js";
+import { createBundleFromSelection, loadBundleFromInput } from "../services/bundle-service.js";
+import { executeBundleApply } from "../services/apply-service.js";
+import {
+  createLocalStackId,
+  getLocalStack,
+  getLocalStacksState,
+  listLocalStacks,
+  saveLocalStack,
+} from "../services/local-stacks.js";
+import { getApiBaseUrl } from "../services/api-base-url.js";
+import { listBackups } from "../backup.js";
+import { getWritePolicyMode } from "./policy.js";
+import type { SelectionInput } from "./types.js";
+import {
+  getTargetMcpSnippet,
+  getTargetSetupGuide,
+  listTargetGuides,
+} from "../services/target-guidance.js";
+import type { IdeId, Scope } from "../../../../packages/core/src/manifest.js";
+
+export class VibebasketMcpServices {
+  readonly sessionId = randomUUID();
+  readonly catalog = new CatalogApiClient();
+
+  async getSessionState() {
+    const localStacks = getLocalStacksState();
+    return {
+      sessionId: this.sessionId,
+      apiBaseUrl: getApiBaseUrl(),
+      writePolicyMode: getWritePolicyMode(),
+      localStacks,
+      cloudStacks: {
+        available: false,
+        reason:
+          "Cloud stack save is not linked in the local MCP yet. Use local stacks here or use the VibeBasket website for profile-backed saved stacks.",
+      },
+      authentication: {
+        cloudSaveLinked: false,
+        guidance:
+          "Sign into the VibeBasket website when you need profile-backed saved stacks. Local MCP currently supports local stack save only.",
+      },
+      localMcp: {
+        command: "npx",
+        args: ["-y", "vibebasket", "mcp", "serve"],
+      },
+    };
+  }
+
+  listTargets() {
+    return listTargetGuides();
+  }
+
+  getTargetSetupGuide(targetId: IdeId, scope?: Scope) {
+    return getTargetSetupGuide(targetId, scope);
+  }
+
+  getTargetMcpSnippet(targetId: IdeId, scope?: Scope) {
+    return getTargetMcpSnippet(targetId, scope);
+  }
+
+  async planInstall(input: SelectionInput) {
+    const { bundle, url } = await createBundleFromSelection({
+      itemIds: input.itemIds,
+      targetIds: input.targetIds,
+      scope: input.scope,
+    });
+
+    const result = await executeBundleApply(bundle, {
+      scope: input.scope,
+      force: false,
+      dryRun: true,
+      verify: false,
+      projectRoot: input.scope === "project" ? process.cwd() : undefined,
+      interactiveSecrets: false,
+    });
+
+    return { bundle, bundleUrl: url, result };
+  }
+
+  async applyInstall(input: { bundleUrl?: string; selection?: SelectionInput; force?: boolean }) {
+    const bundle =
+      input.bundleUrl != null
+        ? await loadBundleFromInput(input.bundleUrl)
+        : (await createBundleFromSelection({
+            itemIds: input.selection!.itemIds,
+            targetIds: input.selection!.targetIds,
+            scope: input.selection!.scope,
+          })).bundle;
+
+    return executeBundleApply(bundle, {
+      scope: input.selection?.scope ?? bundle.scope,
+      force: input.force ?? false,
+      dryRun: false,
+      verify: true,
+      projectRoot: (input.selection?.scope ?? bundle.scope) === "project" ? process.cwd() : undefined,
+      interactiveSecrets: false,
+    });
+  }
+
+  async saveLocalStack(input: SelectionInput) {
+    const snapshots = (
+      await Promise.all(input.itemIds.map((itemId) => this.catalog.getItem(itemId)))
+    )
+      .filter((item): item is NonNullable<typeof item> => item !== null)
+      .map((item) => ({
+        id: item.id,
+        type: item.type,
+        displayName: item.displayName,
+        description: item.description ?? null,
+      }));
+
+    const stack = saveLocalStack({
+      id: createLocalStackId(input.name ?? "stack"),
+      name: input.name ?? "Untitled stack",
+      description: input.description,
+      scope: input.scope,
+      targetIds: input.targetIds,
+      itemIds: input.itemIds,
+      snapshots,
+    });
+
+    return stack;
+  }
+
+  async loadLocalStack(stackId: string) {
+    return getLocalStack(stackId);
+  }
+
+  async listLocalStacks() {
+    return listLocalStacks();
+  }
+
+  async listBackups() {
+    return listBackups();
+  }
+}

--- a/apps/cli/src/mcp/types.ts
+++ b/apps/cli/src/mcp/types.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { IdeIdSchema, ScopeSchema } from "../../../../packages/core/src/manifest.js";
+
+export const WritePolicyModeSchema = z.enum(["confirm", "allow", "deny"]);
+export type WritePolicyMode = z.infer<typeof WritePolicyModeSchema>;
+
+export type McpToolEnvelope<T extends Record<string, unknown> = Record<string, unknown>> = {
+  ok: boolean;
+  data: T;
+  warnings: string[];
+  nextStepHint?: string;
+  errorCode?: string;
+};
+
+export const SelectionInputSchema = z.object({
+  itemIds: z.array(z.string().trim().min(1)).min(1).max(100),
+  targetIds: z.array(IdeIdSchema).min(1).max(20),
+  scope: ScopeSchema.default("user"),
+  name: z.string().trim().min(1).max(80).optional(),
+  description: z.string().trim().max(280).optional(),
+});
+
+export type SelectionInput = z.infer<typeof SelectionInputSchema>;

--- a/apps/cli/src/rollback.ts
+++ b/apps/cli/src/rollback.ts
@@ -1,67 +1,9 @@
-import fs from "node:fs";
 import { confirm, select } from "@inquirer/prompts";
-import type { IdeAdapter } from "@vibebasket/adapters";
 import chalk from "chalk";
 import { listBackups } from "./backup.js";
+import { restoreBackupByPath } from "./services/rollback-service.js";
 
 const MAX_BACKUPS_SHOWN = 10;
-import {
-  AiderAdapter,
-  AntigravityAdapter,
-  ClaudeCodeAdapter,
-  ClineCliAdapter,
-  CodeBuddyAdapter,
-  CodexAdapter,
-  ContinueAdapter,
-  CortexCodeAdapter,
-  CursorAdapter,
-  DeepSeekTuiAdapter,
-  GeminiCliAdapter,
-  GitHubCopilotAdapter,
-  GooseAdapter,
-  HermesAdapter,
-  IBMBobAdapter,
-  JunieAdapter,
-  KiroAdapter,
-  OpenClawAdapter,
-  OpenCodeAdapter,
-  RooCodeAdapter,
-  VSCodeAdapter,
-  VoidAdapter,
-  WindsurfAdapter,
-  ZedAdapter,
-} from "@vibebasket/adapters";
-
-const ADAPTERS = {
-  cursor: new CursorAdapter(),
-  antigravity: new AntigravityAdapter(),
-  windsurf: new WindsurfAdapter(),
-  vscode: new VSCodeAdapter(),
-  "claude-code": new ClaudeCodeAdapter(),
-  "deepseek-tui": new DeepSeekTuiAdapter(),
-  "gemini-cli": new GeminiCliAdapter(),
-  kiro: new KiroAdapter(),
-  junie: new JunieAdapter(),
-  "cline-cli": new ClineCliAdapter(),
-  zed: new ZedAdapter(),
-  codex: new CodexAdapter(),
-  continue: new ContinueAdapter(),
-  roocode: new RooCodeAdapter(),
-  hermes: new HermesAdapter(),
-  openclaw: new OpenClawAdapter(),
-  "github-copilot": new GitHubCopilotAdapter(),
-  void: new VoidAdapter(),
-  aider: new AiderAdapter(),
-  "cortex-code": new CortexCodeAdapter(),
-  goose: new GooseAdapter(),
-  "ibm-bob": new IBMBobAdapter(),
-  codebuddy: new CodeBuddyAdapter(),
-  opencode: new OpenCodeAdapter(),
-} as const;
-
-function getRollbackAdapter(targetId: string): IdeAdapter | undefined {
-  return ADAPTERS[targetId as keyof typeof ADAPTERS];
-}
 
 export async function runRollback() {
   console.log(chalk.yellow("🧺 VibeBasket: Rollback utility\n"));
@@ -93,16 +35,6 @@ export async function runRollback() {
     return;
   }
 
-  const targetId = selectedBackup.targetId as string;
-  const adapter = getRollbackAdapter(targetId);
-  if (!adapter) {
-    throw new Error(`No adapter found for target: ${targetId}`);
-  }
-
-  const configContent = fs.readFileSync(selectedBackup.path, "utf-8");
-  const config = JSON.parse(configContent);
-  const projectRoot = selectedBackup.scope === "project" ? process.cwd() : undefined;
-
-  await adapter.writeConfig(selectedBackup.scope, config, projectRoot);
+  await restoreBackupByPath(selectedBackup.path);
   console.log(chalk.green(`\n✅ Successfully restored ${selectedBackup.targetId} configuration.`));
 }

--- a/apps/cli/src/runtime/adapters.ts
+++ b/apps/cli/src/runtime/adapters.ts
@@ -1,0 +1,63 @@
+import {
+  AiderAdapter,
+  AntigravityAdapter,
+  ClaudeCodeAdapter,
+  ClineCliAdapter,
+  CodeBuddyAdapter,
+  CodexAdapter,
+  ContinueAdapter,
+  CortexCodeAdapter,
+  CursorAdapter,
+  DeepSeekTuiAdapter,
+  GeminiCliAdapter,
+  GitHubCopilotAdapter,
+  GooseAdapter,
+  HermesAdapter,
+  IBMBobAdapter,
+  JunieAdapter,
+  KiroAdapter,
+  OpenClawAdapter,
+  OpenCodeAdapter,
+  RooCodeAdapter,
+  VSCodeAdapter,
+  VoidAdapter,
+  WindsurfAdapter,
+  ZedAdapter,
+} from "@vibebasket/adapters";
+import type { IdeAdapter } from "@vibebasket/adapters";
+import type { IdeId } from "../../../packages/core/src/manifest.js";
+
+export const ADAPTERS: Record<IdeId, IdeAdapter> = {
+  cursor: new CursorAdapter(),
+  antigravity: new AntigravityAdapter(),
+  windsurf: new WindsurfAdapter(),
+  vscode: new VSCodeAdapter(),
+  "claude-code": new ClaudeCodeAdapter(),
+  "deepseek-tui": new DeepSeekTuiAdapter(),
+  "gemini-cli": new GeminiCliAdapter(),
+  kiro: new KiroAdapter(),
+  junie: new JunieAdapter(),
+  "cline-cli": new ClineCliAdapter(),
+  zed: new ZedAdapter(),
+  codex: new CodexAdapter(),
+  continue: new ContinueAdapter(),
+  roocode: new RooCodeAdapter(),
+  hermes: new HermesAdapter(),
+  openclaw: new OpenClawAdapter(),
+  "github-copilot": new GitHubCopilotAdapter(),
+  void: new VoidAdapter(),
+  aider: new AiderAdapter(),
+  "cortex-code": new CortexCodeAdapter(),
+  goose: new GooseAdapter(),
+  "ibm-bob": new IBMBobAdapter(),
+  codebuddy: new CodeBuddyAdapter(),
+  opencode: new OpenCodeAdapter(),
+};
+
+export function getAdapter(targetId: IdeId): IdeAdapter | undefined {
+  return ADAPTERS[targetId];
+}
+
+export function getAllAdapters(): Array<[IdeId, IdeAdapter]> {
+  return Object.entries(ADAPTERS) as Array<[IdeId, IdeAdapter]>;
+}

--- a/apps/cli/src/search.ts
+++ b/apps/cli/src/search.ts
@@ -1,8 +1,5 @@
 import chalk from "chalk";
-
-function getApiBaseUrl(): string {
-  return process.env.VIBEBASKET_API_URL || "https://vibebasket.dev";
-}
+import { getApiBaseUrl } from "./services/api-base-url.js";
 
 export async function runSearch(query: string) {
   const q = encodeURIComponent(query.trim());

--- a/apps/cli/src/secrets.ts
+++ b/apps/cli/src/secrets.ts
@@ -32,8 +32,10 @@ async function loadKeytar(): Promise<KeytarModule | null> {
 export async function resolveSecrets(
   requiredSecrets: string[],
   projectRoot: string = process.cwd(),
+  options: { interactive?: boolean } = {},
 ): Promise<Record<string, string>> {
   const secrets: Record<string, string> = {};
+  const interactive = options.interactive !== false;
 
   // 1. Load from .vibebasket.env if exists
   const envPath = path.join(projectRoot, ".vibebasket.env");
@@ -64,6 +66,10 @@ export async function resolveSecrets(
         secrets[name] = keychainSecret;
         continue;
       }
+    }
+
+    if (!interactive) {
+      throw new Error(`Missing required secret: ${name}`);
     }
 
     // 5. Interactive Prompt

--- a/apps/cli/src/services/api-base-url.ts
+++ b/apps/cli/src/services/api-base-url.ts
@@ -1,0 +1,8 @@
+export function getApiBaseUrl(): string {
+  return process.env.VIBEBASKET_API_URL || "https://vibebasket.dev";
+}
+
+export function getCatalogRefreshToken(): string | null {
+  const token = process.env.VIBEBASKET_CATALOG_REFRESH_TOKEN?.trim();
+  return token ? token : null;
+}

--- a/apps/cli/src/services/apply-service.ts
+++ b/apps/cli/src/services/apply-service.ts
@@ -1,0 +1,332 @@
+import type { IdeAdapter } from "@vibebasket/adapters";
+import type { ManagedContentApplyOutcome } from "@vibebasket/adapters";
+import type { Bundle, IdeId, Scope } from "../../../packages/core/src/manifest.js";
+import {
+  buildTargetMcpApplyPlan,
+  flattenBundleContent,
+  getUnsupportedTargetContent,
+} from "../apply-helpers.js";
+import { createBackup } from "../backup.js";
+import { formatVerificationSummary, verifyTargetInstall } from "../install-verification.js";
+import { getAdapter } from "../runtime/adapters.js";
+import { resolveSecrets } from "../secrets.js";
+import { applyWorkflowFiles } from "../workflow-files.js";
+
+export interface ApplyLogger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+export interface ApplyServiceOptions {
+  scope?: Scope;
+  force?: boolean;
+  dryRun?: boolean;
+  verify?: boolean;
+  projectRoot?: string;
+  interactiveSecrets?: boolean;
+  logger?: ApplyLogger;
+}
+
+export interface TargetApplyResult {
+  targetId: IdeId;
+  displayName: string;
+  applied: boolean;
+  dryRun: boolean;
+  skippedReason?: string;
+  backupPath?: string;
+  postInstallHint?: string;
+  verificationSummary?: string;
+  managedContent?: {
+    rules?: ManagedContentApplyOutcome;
+    skills?: ManagedContentApplyOutcome;
+  };
+}
+
+export interface ApplyServiceResult {
+  bundle: Bundle;
+  scope: Scope;
+  workflowFilesApplied: string[];
+  workflowFilesSkipped: Array<{ path: string; reason: string }>;
+  unsupportedFeatureMessages: string[];
+  requiredSecrets: string[];
+  targetResults: TargetApplyResult[];
+  failedTargets: Array<{ targetId: IdeId; error: string }>;
+}
+
+const noopLogger: ApplyLogger = {
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([left], [right]) =>
+      left.localeCompare(right),
+    );
+    return `{${entries
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function summarizeManagedContent(result: ManagedContentApplyOutcome) {
+  if (!result) {
+    return "applied";
+  }
+
+  const summary: string[] = [];
+  if (result.written.length > 0) summary.push(`${result.written.length} written`);
+  if (result.updated.length > 0) summary.push(`${result.updated.length} updated`);
+  if (result.unchanged.length > 0) summary.push(`${result.unchanged.length} unchanged`);
+  if (result.skipped.length > 0) summary.push(`${result.skipped.length} skipped`);
+  return summary.join(", ") || "applied";
+}
+
+export async function executeBundleApply(
+  bundle: Bundle,
+  options: ApplyServiceOptions = {},
+): Promise<ApplyServiceResult> {
+  const logger = options.logger ?? noopLogger;
+  const scope = options.scope ?? bundle.scope;
+  const projectRoot = scope === "project" ? options.projectRoot ?? process.cwd() : undefined;
+  const flattened = flattenBundleContent(bundle);
+
+  const unsupportedTargets = bundle.targets.filter((targetId) => !getAdapter(targetId));
+  if (unsupportedTargets.length > 0) {
+    throw new Error(
+      `This bundle references targets the current apply engine cannot install yet: ${unsupportedTargets.join(", ")}.`,
+    );
+  }
+
+  const scopeUnsupportedTargets = bundle.targets.filter((targetId) => {
+    const adapter = getAdapter(targetId);
+    return adapter ? !adapter.supportedScopes.includes(scope) : false;
+  });
+  if (scopeUnsupportedTargets.length > 0) {
+    throw new Error(
+      `This bundle cannot be applied at ${scope} scope for: ${scopeUnsupportedTargets.join(", ")}.`,
+    );
+  }
+
+  const unsupportedFeatureMessages: string[] = [];
+  const mcpPlans = new Map<IdeId, ReturnType<typeof buildTargetMcpApplyPlan>>();
+
+  for (const targetId of bundle.targets) {
+    const adapter = getAdapter(targetId);
+    if (!adapter) continue;
+
+    const mcpPlan = buildTargetMcpApplyPlan(targetId, adapter, flattened.mcps);
+    mcpPlans.set(targetId, mcpPlan);
+
+    const unsupportedFeatures = getUnsupportedTargetContent(adapter, flattened);
+    if (unsupportedFeatures.length > 0) {
+      unsupportedFeatureMessages.push(`${adapter.displayName}: ${unsupportedFeatures.join(", ")}`);
+    }
+
+    if (mcpPlan.skipped.length > 0) {
+      unsupportedFeatureMessages.push(
+        `${adapter.displayName}: skipped MCPs -> ${mcpPlan.skipped
+          .map((item) => `${item.displayName} (${item.reason})`)
+          .join(", ")}`,
+      );
+    }
+  }
+
+  const requiredSecrets = Array.from(
+    new Set(Array.from(mcpPlans.values()).flatMap((plan) => plan.requiredSecrets)),
+  );
+  const secretProjectRoot = projectRoot ?? process.cwd();
+  const interactiveSecrets = options.interactiveSecrets ?? true;
+  const secrets =
+    interactiveSecrets && secretProjectRoot === process.cwd()
+      ? await resolveSecrets(requiredSecrets)
+      : await resolveSecrets(requiredSecrets, secretProjectRoot, {
+          interactive: interactiveSecrets,
+        });
+
+  const workflowFilesApplied: string[] = [];
+  const workflowFilesSkipped: Array<{ path: string; reason: string }> = [];
+  if (flattened.files.length > 0) {
+    if (!projectRoot) {
+      logger.warn(
+        "Workflow files were included, but file scaffolds only apply in project scope. Skipping workflow files.",
+      );
+    } else if (options.dryRun) {
+      logger.info(`Dry run: would apply ${flattened.files.length} workflow file(s) under ${projectRoot}.`);
+    } else {
+      const workflowResult = await applyWorkflowFiles(flattened.files, projectRoot);
+      workflowFilesApplied.push(...workflowResult.written);
+      workflowFilesSkipped.push(...workflowResult.skipped);
+    }
+  }
+
+  const targetResults: TargetApplyResult[] = [];
+  const failedTargets: Array<{ targetId: IdeId; error: string }> = [];
+
+  for (const targetId of bundle.targets) {
+    const adapter = getAdapter(targetId);
+    const mcpPlan = mcpPlans.get(targetId);
+    if (!adapter || !mcpPlan) {
+      continue;
+    }
+
+    try {
+      const targetResult = await applyToTarget(
+        targetId,
+        adapter,
+        bundle,
+        mcpPlan,
+        flattened,
+        secrets,
+        {
+          scope,
+          force: options.force ?? false,
+          dryRun: options.dryRun ?? false,
+          verify: options.verify !== false,
+          projectRoot,
+          logger,
+        },
+      );
+      targetResults.push(targetResult);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      failedTargets.push({ targetId, error: message });
+      logger.error(`Failed to apply to ${targetId}: ${message}`);
+    }
+  }
+
+  return {
+    bundle,
+    scope,
+    workflowFilesApplied,
+    workflowFilesSkipped,
+    unsupportedFeatureMessages,
+    requiredSecrets,
+    targetResults,
+    failedTargets,
+  };
+}
+
+async function applyToTarget(
+  targetId: IdeId,
+  adapter: IdeAdapter,
+  bundle: Bundle,
+  mcpPlan: ReturnType<typeof buildTargetMcpApplyPlan>,
+  flattened: ReturnType<typeof flattenBundleContent>,
+  secrets: Record<string, string>,
+  options: {
+    scope: Scope;
+    force: boolean;
+    dryRun: boolean;
+    verify: boolean;
+    projectRoot?: string;
+    logger: ApplyLogger;
+  },
+): Promise<TargetApplyResult> {
+  const shouldApplyMcps = adapter.supportsMcp && mcpPlan.supported.length > 0;
+  const shouldApplyRules =
+    adapter.supportsRules && Boolean(adapter.applyRules) && flattened.rules.length > 0;
+  const shouldApplySkills =
+    adapter.supportsSkills && Boolean(adapter.applySkills) && flattened.skills.length > 0;
+
+  if (!shouldApplyMcps && !shouldApplyRules && !shouldApplySkills) {
+    const skippedReason =
+      mcpPlan.skipped.length > 0
+        ? mcpPlan.skipped.map((item) => `${item.displayName} (${item.reason})`).join(", ")
+        : `no compatible content for ${adapter.displayName}`;
+    return {
+      targetId,
+      displayName: adapter.displayName,
+      applied: false,
+      dryRun: options.dryRun,
+      skippedReason,
+    };
+  }
+
+  let backupPath: string | undefined;
+  let verificationSummary: string | undefined;
+  let ruleOutcome: ManagedContentApplyOutcome | undefined;
+  let skillOutcome: ManagedContentApplyOutcome | undefined;
+
+  if (mcpPlan.credentialNotice) {
+    options.logger.info(mcpPlan.credentialNotice);
+  }
+
+  if (options.dryRun) {
+    if (shouldApplyMcps) {
+      const currentConfig = await adapter.readConfig(options.scope, options.projectRoot);
+      const pendingConfig = adapter.applyMcps(currentConfig, mcpPlan.supported, secrets, {
+        force: options.force,
+      });
+      const diff = await adapter.diff(options.scope, pendingConfig, options.projectRoot);
+      options.logger.info(`Dry run diff for ${adapter.displayName}:\n${diff}`);
+    }
+
+    return {
+      targetId,
+      displayName: adapter.displayName,
+      applied: true,
+      dryRun: true,
+      postInstallHint: adapter.postInstallHint(),
+    };
+  }
+
+  if (shouldApplyMcps) {
+    const currentConfig = await adapter.readConfig(options.scope, options.projectRoot);
+    const pendingConfig = adapter.applyMcps(currentConfig, mcpPlan.supported, secrets, {
+      force: options.force,
+    });
+
+    if (stableStringify(currentConfig) !== stableStringify(pendingConfig)) {
+      backupPath = await createBackup(targetId, options.scope, currentConfig);
+      await adapter.writeConfig(options.scope, pendingConfig, options.projectRoot);
+    }
+  }
+
+  if (shouldApplyRules && adapter.applyRules) {
+    ruleOutcome = await adapter.applyRules(flattened.rules, options.scope, options.projectRoot);
+    options.logger.info(`${adapter.displayName} rules: ${summarizeManagedContent(ruleOutcome)}`);
+  }
+
+  if (shouldApplySkills && adapter.applySkills) {
+    skillOutcome = await adapter.applySkills(flattened.skills, options.scope, options.projectRoot);
+    options.logger.info(`${adapter.displayName} skills: ${summarizeManagedContent(skillOutcome)}`);
+  }
+
+  if (options.verify) {
+    const verification = await verifyTargetInstall(targetId, adapter, options.scope, options.projectRoot, {
+      mcps: shouldApplyMcps ? mcpPlan.supported : [],
+      skills: shouldApplySkills ? flattened.skills : [],
+      rules: shouldApplyRules ? flattened.rules : [],
+    });
+
+    if (!verification.ok) {
+      throw new Error(
+        `Post-install verification failed (${formatVerificationSummary(verification)})`,
+      );
+    }
+    verificationSummary = formatVerificationSummary(verification);
+  }
+
+  return {
+    targetId,
+    displayName: adapter.displayName,
+    applied: true,
+    dryRun: false,
+    backupPath,
+    postInstallHint: adapter.postInstallHint(),
+    verificationSummary,
+    managedContent: {
+      ...(ruleOutcome ? { rules: ruleOutcome } : {}),
+      ...(skillOutcome ? { skills: skillOutcome } : {}),
+    },
+  };
+}

--- a/apps/cli/src/services/bundle-service.ts
+++ b/apps/cli/src/services/bundle-service.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import {
+  BundleSchema,
+  type Bundle,
+  type IdeId,
+  type Scope,
+} from "../../../../packages/core/src/manifest.js";
+import { getApiBaseUrl } from "./api-base-url.js";
+
+export async function loadBundleFromInput(input: string): Promise<Bundle> {
+  let manifest: unknown;
+
+  if (input.startsWith("http://") || input.startsWith("https://")) {
+    const response = await fetch(input, { signal: AbortSignal.timeout(15_000) });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch bundle: ${response.status} ${response.statusText}`);
+    }
+    manifest = await response.json();
+  } else {
+    manifest = JSON.parse(fs.readFileSync(input, "utf8"));
+  }
+
+  return BundleSchema.parse(manifest);
+}
+
+export async function createBundleFromSelection(input: {
+  itemIds: string[];
+  targetIds: IdeId[];
+  scope: Scope;
+  apiBaseUrl?: string;
+}): Promise<{ url: string; bundle: Bundle }> {
+  const apiBaseUrl = (input.apiBaseUrl ?? getApiBaseUrl()).replace(/\/+$/, "");
+  const response = await fetch(`${apiBaseUrl}/api/bundle`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      itemIds: input.itemIds,
+      targets: input.targetIds,
+      scope: input.scope,
+    }),
+    signal: AbortSignal.timeout(20_000),
+  });
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    const detail =
+      payload && typeof payload === "object" && "error" in payload
+        ? String(payload.error)
+        : response.statusText;
+    throw new Error(`Failed to create bundle: ${detail}`);
+  }
+
+  const payload = (await response.json()) as { url: string };
+  const bundle = await loadBundleFromInput(payload.url);
+  return { url: payload.url, bundle };
+}

--- a/apps/cli/src/services/catalog-api.test.ts
+++ b/apps/cli/src/services/catalog-api.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CatalogApiClient } from "./catalog-api.js";
+
+describe("CatalogApiClient refresh guardrails", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-23T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("deduplicates concurrent refresh calls in flight", async () => {
+    let calls = 0;
+    let resolveFetch: (() => void) | null = null;
+
+    global.fetch = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          calls += 1;
+          resolveFetch = () =>
+            resolve(
+              new Response(JSON.stringify({ items: [], pagination: undefined, source: "network", cached: false }), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              }),
+            );
+        }),
+    ) as typeof fetch;
+
+    const client = new CatalogApiClient("https://vibebasket.dev");
+    const first = client.refresh();
+    const second = client.refresh();
+
+    expect(calls).toBe(1);
+
+    resolveFetch?.();
+
+    await expect(first).resolves.toMatchObject({ refreshed: true });
+    await expect(second).resolves.toMatchObject({ refreshed: true });
+  });
+
+  it("enforces cooldown after a successful refresh", async () => {
+    global.fetch = vi.fn(async () => new Response("{}", { status: 200 })) as typeof fetch;
+
+    const client = new CatalogApiClient("https://vibebasket.dev");
+    await expect(client.refresh()).resolves.toMatchObject({ refreshed: true, cooldownMsRemaining: 0 });
+    await expect(client.refresh()).resolves.toMatchObject({
+      refreshed: false,
+      forced: false,
+      cooldownMsRemaining: 300000,
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/cli/src/services/catalog-api.ts
+++ b/apps/cli/src/services/catalog-api.ts
@@ -1,0 +1,242 @@
+import { getApiBaseUrl, getCatalogRefreshToken } from "./api-base-url.js";
+
+const SEARCH_CACHE_TTL_MS = 5 * 60 * 1000;
+const ITEM_CACHE_TTL_MS = 10 * 60 * 1000;
+const REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 200;
+
+export interface CatalogSearchInput {
+  query: string;
+  type?: "mcp" | "skill" | "rule" | "workflow";
+  trust?: "all" | "verified" | "official" | "community";
+  freshness?: "all" | "fresh" | "recent" | "aging";
+  sort?: "recommended" | "freshest" | "name";
+  page?: number;
+  limit?: number;
+}
+
+export interface CatalogItemSummary {
+  id: string;
+  type: "mcp" | "skill" | "rule" | "workflow";
+  displayName: string;
+  description: string | null;
+  sourceName?: string | null;
+  sourceUrl?: string | null;
+  verified?: boolean;
+  official?: boolean;
+  lastSyncedAt?: string | Date | null;
+  data?: unknown;
+}
+
+export interface CatalogSearchResult {
+  items: CatalogItemSummary[];
+  pagination?: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+  };
+  source: "network";
+  cached: boolean;
+}
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+function now() {
+  return Date.now();
+}
+
+function buildSearchCacheKey(input: CatalogSearchInput) {
+  return JSON.stringify({
+    q: input.query.trim().toLowerCase(),
+    type: input.type ?? null,
+    trust: input.trust ?? "all",
+    freshness: input.freshness ?? "all",
+    sort: input.sort ?? "recommended",
+    page: input.page ?? 1,
+    limit: input.limit ?? 24,
+  });
+}
+
+function buildFetchOptions(timeoutMs: number, headers?: Record<string, string>) {
+  return {
+    headers,
+    signal: AbortSignal.timeout(timeoutMs),
+  };
+}
+
+function pruneCache<T>(cache: Map<string, CacheEntry<T>>) {
+  const timestamp = now();
+  for (const [key, entry] of cache) {
+    if (entry.expiresAt <= timestamp) {
+      cache.delete(key);
+    }
+  }
+
+  while (cache.size > MAX_CACHE_ENTRIES) {
+    const firstKey = cache.keys().next().value;
+    if (!firstKey) {
+      break;
+    }
+    cache.delete(firstKey);
+  }
+}
+
+export class CatalogApiClient {
+  private readonly baseUrl: string;
+  private readonly searchCache = new Map<string, CacheEntry<CatalogSearchResult>>();
+  private readonly itemCache = new Map<string, CacheEntry<CatalogItemSummary>>();
+  private inFlightRefresh: Promise<{
+    refreshed: boolean;
+    cooldownMsRemaining: number;
+    forced: boolean;
+  }> | null = null;
+  private lastRefreshAt = 0;
+
+  constructor(baseUrl: string = getApiBaseUrl()) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+  }
+
+  private getCached<T>(cache: Map<string, CacheEntry<T>>, key: string): T | null {
+    const entry = cache.get(key);
+    if (!entry) {
+      return null;
+    }
+
+    if (entry.expiresAt <= now()) {
+      cache.delete(key);
+      return null;
+    }
+
+    return entry.value;
+  }
+
+  private setCached<T>(cache: Map<string, CacheEntry<T>>, key: string, value: T, ttlMs: number) {
+    cache.set(key, { value, expiresAt: now() + ttlMs });
+    pruneCache(cache);
+  }
+
+  getBaseUrl() {
+    return this.baseUrl;
+  }
+
+  async search(input: CatalogSearchInput): Promise<CatalogSearchResult> {
+    const normalizedQuery = input.query.trim();
+    const searchInput = {
+      ...input,
+      query: normalizedQuery,
+      page: input.page ?? 1,
+      limit: input.limit ?? 24,
+      sort: input.sort ?? "recommended",
+      trust: input.trust ?? "all",
+      freshness: input.freshness ?? "all",
+    };
+    const cacheKey = buildSearchCacheKey(searchInput);
+    const cached = this.getCached(this.searchCache, cacheKey);
+    if (cached) {
+      return { ...cached, cached: true };
+    }
+
+    const params = new URLSearchParams();
+    params.set("q", normalizedQuery);
+    params.set("page", `${searchInput.page}`);
+    params.set("limit", `${searchInput.limit}`);
+    params.set("sort", searchInput.sort);
+    params.set("trust", searchInput.trust);
+    params.set("freshness", searchInput.freshness);
+    if (searchInput.type) {
+      params.set("type", searchInput.type);
+    }
+
+    const response = await fetch(
+      `${this.baseUrl}/api/catalog?${params.toString()}`,
+      buildFetchOptions(15_000),
+    );
+    if (!response.ok) {
+      throw new Error(`Catalog API error: ${response.status} ${response.statusText}`);
+    }
+
+    const payload = (await response.json()) as CatalogSearchResult;
+    const result: CatalogSearchResult = {
+      ...payload,
+      source: "network",
+      cached: false,
+    };
+
+    this.setCached(this.searchCache, cacheKey, result, SEARCH_CACHE_TTL_MS);
+    for (const item of result.items) {
+      this.setCached(this.itemCache, item.id, item, ITEM_CACHE_TTL_MS);
+    }
+
+    return result;
+  }
+
+  async getItem(id: string): Promise<CatalogItemSummary | null> {
+    const cached = this.getCached(this.itemCache, id);
+    if (cached) {
+      return cached;
+    }
+
+    const response = await fetch(
+      `${this.baseUrl}/api/catalog/item/${encodeURIComponent(id)}`,
+      buildFetchOptions(10_000),
+    );
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      throw new Error(`Catalog item API error: ${response.status} ${response.statusText}`);
+    }
+
+    const payload = (await response.json()) as CatalogItemSummary;
+    this.setCached(this.itemCache, id, payload, ITEM_CACHE_TTL_MS);
+    return payload;
+  }
+
+  async refresh(): Promise<{ refreshed: boolean; cooldownMsRemaining: number; forced: boolean }> {
+    const timestamp = now();
+    const cooldownMsRemaining = Math.max(0, REFRESH_COOLDOWN_MS - (timestamp - this.lastRefreshAt));
+    if (cooldownMsRemaining > 0) {
+      return { refreshed: false, cooldownMsRemaining, forced: false };
+    }
+
+    if (this.inFlightRefresh) {
+      return this.inFlightRefresh;
+    }
+
+    this.inFlightRefresh = (async () => {
+      const headers: Record<string, string> = {};
+      const refreshToken = getCatalogRefreshToken();
+      const params = new URLSearchParams({ limit: "1" });
+      let forced = false;
+      if (refreshToken) {
+        headers["x-vibebasket-refresh-token"] = refreshToken;
+        params.set("refresh", "1");
+        forced = true;
+      }
+
+      const response = await fetch(
+        `${this.baseUrl}/api/catalog?${params.toString()}`,
+        buildFetchOptions(30_000, headers),
+      );
+      if (!response.ok) {
+        throw new Error(`Catalog refresh failed: ${response.status} ${response.statusText}`);
+      }
+
+      this.searchCache.clear();
+      this.itemCache.clear();
+      this.lastRefreshAt = now();
+
+      return { refreshed: true, cooldownMsRemaining: 0, forced };
+    })().finally(() => {
+      this.inFlightRefresh = null;
+    });
+
+    return this.inFlightRefresh;
+  }
+}

--- a/apps/cli/src/services/local-stacks.test.ts
+++ b/apps/cli/src/services/local-stacks.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createLocalStackId,
+  getLocalStack,
+  listLocalStacks,
+  saveLocalStack,
+} from "./local-stacks.js";
+
+describe("local stack storage", () => {
+  let tempHome: string;
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "vibebasket-stacks-"));
+    vi.spyOn(os, "homedir").mockReturnValue(tempHome);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("saves and loads a local stack", () => {
+    const stack = saveLocalStack({
+      id: "react-stack",
+      name: "React Stack",
+      scope: "user",
+      targetIds: ["cursor"],
+      itemIds: ["item-1"],
+      snapshots: [],
+    });
+
+    expect(stack.id).toBe("react-stack");
+    expect(getLocalStack("react-stack")?.name).toBe("React Stack");
+  });
+
+  it("lists stacks in newest-first order", async () => {
+    saveLocalStack({
+      id: "first-stack",
+      name: "First Stack",
+      scope: "user",
+      targetIds: ["cursor"],
+      itemIds: ["item-1"],
+      snapshots: [],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    saveLocalStack({
+      id: "second-stack",
+      name: "Second Stack",
+      scope: "user",
+      targetIds: ["claude-code"],
+      itemIds: ["item-2"],
+      snapshots: [],
+    });
+
+    expect(listLocalStacks().map((entry) => entry.id)).toEqual(["second-stack", "first-stack"]);
+  });
+
+  it("creates unique stack ids from colliding names", () => {
+    saveLocalStack({
+      id: "react-stack",
+      name: "React Stack",
+      scope: "user",
+      targetIds: ["cursor"],
+      itemIds: ["item-1"],
+      snapshots: [],
+    });
+
+    expect(createLocalStackId("React Stack")).toBe("react-stack-2");
+  });
+
+  it("returns null for invalid stack ids instead of traversing paths", () => {
+    expect(getLocalStack("../secrets")).toBeNull();
+    expect(getLocalStack("bad/name")).toBeNull();
+  });
+
+  it("skips malformed stack files during listing", () => {
+    saveLocalStack({
+      id: "valid-stack",
+      name: "Valid Stack",
+      scope: "user",
+      targetIds: ["cursor"],
+      itemIds: ["item-1"],
+      snapshots: [],
+    });
+
+    const stacksDir = path.join(tempHome, ".vibebasket", "stacks");
+    fs.writeFileSync(path.join(stacksDir, "broken.json"), "{not-json");
+
+    expect(listLocalStacks().map((entry) => entry.id)).toEqual(["valid-stack"]);
+  });
+});

--- a/apps/cli/src/services/local-stacks.ts
+++ b/apps/cli/src/services/local-stacks.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { z } from "zod";
+import { IdeIdSchema, ScopeSchema } from "../../../../packages/core/src/manifest.js";
+
+const LOCAL_STACK_SCHEMA_VERSION = "1";
+const LOCAL_STACK_ID_PATTERN = /^[a-z0-9-]+$/;
+
+const LocalStackItemSnapshotSchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(["mcp", "skill", "rule", "workflow"]),
+  displayName: z.string().min(1),
+  description: z.string().nullable().optional(),
+});
+
+const LocalStackDocumentSchema = z.object({
+  schemaVersion: z.literal(LOCAL_STACK_SCHEMA_VERSION),
+  id: z.string().regex(/^[a-z0-9-]+$/),
+  name: z.string().trim().min(1).max(80),
+  description: z.string().trim().max(280).optional(),
+  scope: ScopeSchema,
+  targetIds: z.array(IdeIdSchema).min(1).max(20),
+  itemIds: z.array(z.string().trim().min(1)).min(1).max(100),
+  snapshots: z.array(LocalStackItemSnapshotSchema).default([]),
+  savedAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type LocalStackDocument = z.infer<typeof LocalStackDocumentSchema>;
+
+function getStacksDir() {
+  return path.join(os.homedir(), ".vibebasket", "stacks");
+}
+
+function ensureStacksDir() {
+  fs.mkdirSync(getStacksDir(), { recursive: true });
+}
+
+function sanitizeId(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
+
+function getStackPath(stackId: string) {
+  if (!LOCAL_STACK_ID_PATTERN.test(stackId)) {
+    throw new Error("Invalid local stack id.");
+  }
+  return path.join(getStacksDir(), `${stackId}.json`);
+}
+
+export function getLocalStacksState() {
+  const dir = getStacksDir();
+  return {
+    available: true,
+    path: dir,
+    exists: fs.existsSync(dir),
+  };
+}
+
+export function listLocalStacks(): LocalStackDocument[] {
+  if (!fs.existsSync(getStacksDir())) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(getStacksDir())
+    .filter((entry) => entry.endsWith(".json"))
+    .flatMap((entry) => {
+      try {
+        const fullPath = path.join(getStacksDir(), entry);
+        const raw = fs.readFileSync(fullPath, "utf8");
+        return [LocalStackDocumentSchema.parse(JSON.parse(raw))];
+      } catch {
+        return [];
+      }
+    })
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+export function getLocalStack(stackId: string): LocalStackDocument | null {
+  let fullPath: string;
+  try {
+    fullPath = getStackPath(stackId);
+  } catch {
+    return null;
+  }
+  if (!fs.existsSync(fullPath)) {
+    return null;
+  }
+
+  try {
+    const raw = fs.readFileSync(fullPath, "utf8");
+    return LocalStackDocumentSchema.parse(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function saveLocalStack(
+  input: Omit<LocalStackDocument, "schemaVersion" | "savedAt" | "updatedAt">,
+): LocalStackDocument {
+  ensureStacksDir();
+
+  const timestamp = new Date().toISOString();
+  const existing = getLocalStack(input.id);
+  const nextDocument: LocalStackDocument = {
+    schemaVersion: LOCAL_STACK_SCHEMA_VERSION,
+    ...input,
+    savedAt: existing?.savedAt ?? timestamp,
+    updatedAt: timestamp,
+  };
+  const validated = LocalStackDocumentSchema.parse(nextDocument);
+  fs.writeFileSync(getStackPath(validated.id), JSON.stringify(validated, null, 2));
+  return validated;
+}
+
+export function createLocalStackId(name: string) {
+  const base = sanitizeId(name) || "stack";
+  let candidate = base;
+  let counter = 2;
+
+  while (fs.existsSync(getStackPath(candidate))) {
+    candidate = `${base}-${counter}`;
+    counter += 1;
+  }
+
+  return candidate;
+}

--- a/apps/cli/src/services/rollback-service.test.ts
+++ b/apps/cli/src/services/rollback-service.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const writeConfigMock = vi.fn();
+
+vi.mock("../runtime/adapters.js", () => ({
+  getAdapter: vi.fn(() => ({
+    displayName: "Cursor",
+    writeConfig: writeConfigMock,
+  })),
+}));
+
+describe("restoreBackupByPath", () => {
+  const originalCwd = process.cwd();
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(fs.realpathSync("/tmp"), "vibebasket-rollback-"));
+    process.chdir(tempDir);
+    fs.mkdirSync(path.join(tempDir, ".vibebasket", "backups"), { recursive: true });
+    writeConfigMock.mockReset();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("restores a backup by filename", async () => {
+    const backupFilename = "cursor-user-2026-07-23T12-00-00-000Z.json";
+    const backupPath = path.join(tempDir, ".vibebasket", "backups", backupFilename);
+    fs.writeFileSync(backupPath, JSON.stringify({ mcpServers: {} }));
+
+    const { restoreBackupByPath } = await import("./rollback-service.js");
+    const result = await restoreBackupByPath(backupFilename);
+
+    expect(result.restored).toBe(true);
+    expect(result.targetId).toBe("cursor");
+    expect(writeConfigMock).toHaveBeenCalledWith("user", { mcpServers: {} }, undefined);
+  });
+});

--- a/apps/cli/src/services/rollback-service.ts
+++ b/apps/cli/src/services/rollback-service.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import type { IdeId } from "../../../../packages/core/src/manifest.js";
+import { listBackups } from "../backup.js";
+import { getAdapter } from "../runtime/adapters.js";
+
+export async function restoreBackupByPath(backupPathOrFilename: string) {
+  const backups = listBackups();
+  const backup = backups.find(
+    (entry) => entry.path === backupPathOrFilename || entry.filename === backupPathOrFilename,
+  );
+
+  if (!backup) {
+    throw new Error(`Backup not found: ${backupPathOrFilename}`);
+  }
+
+  const adapter = getAdapter(backup.targetId as IdeId);
+  if (!adapter) {
+    throw new Error(`No adapter found for target: ${backup.targetId}`);
+  }
+
+  const configContent = fs.readFileSync(backup.path, "utf8");
+  const config = JSON.parse(configContent);
+  const projectRoot = backup.scope === "project" ? process.cwd() : undefined;
+
+  await adapter.writeConfig(backup.scope, config, projectRoot);
+
+  return {
+    restored: true,
+    targetId: backup.targetId,
+    displayName: adapter.displayName,
+    scope: backup.scope,
+    path: backup.path,
+    timestamp: backup.timestamp,
+  };
+}

--- a/apps/cli/src/services/target-guidance.test.ts
+++ b/apps/cli/src/services/target-guidance.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { getTargetMcpSnippet, getTargetSetupGuide, listTargetGuides } from "./target-guidance.js";
+
+describe("target guidance", () => {
+  it("lists supported targets in alphabetical order", () => {
+    const targets = listTargetGuides();
+    expect(targets).toHaveLength(24);
+    expect(targets[0]?.label).toBe("Aider");
+    expect(targets.at(-1)?.label).toBe("Zed");
+  });
+
+  it("returns MCP setup guidance for a target that supports MCP", () => {
+    const guide = getTargetSetupGuide("cursor", "project");
+
+    expect(guide.scopeSupported).toBe(true);
+    expect(guide.supportsMcp).toBe(true);
+    expect(guide.configPathHint).toBe("<project-root>/.cursor/mcp.json");
+    expect(guide.vibebasketServer).toMatchObject({
+      serverId: "vibebasket",
+      command: "npx",
+      args: ["-y", "vibebasket", "mcp", "serve"],
+    });
+  });
+
+  it("returns a non-MCP guide for capability-limited targets", () => {
+    const guide = getTargetSetupGuide("github-copilot", "project");
+
+    expect(guide.supportsMcp).toBe(false);
+    expect(guide.vibebasketServer).toBeNull();
+    expect(guide.recommendedSteps[0]).toContain("does not expose MCP");
+  });
+
+  it("returns a native JSON snippet for cursor", () => {
+    const snippet = getTargetMcpSnippet("cursor", "project");
+
+    expect(snippet.scopeSupported).toBe(true);
+    expect(snippet.snippetLanguage).toBe("json");
+    expect(snippet.rootField).toBe("mcpServers");
+    expect(snippet.snippet).toContain('"mcpServers"');
+    expect(snippet.snippet).toContain('"vibebasket"');
+    expect(snippet.snippet).toContain('"command": "npx"');
+  });
+
+  it("returns a native TOML snippet for codex", () => {
+    const snippet = getTargetMcpSnippet("codex", "user");
+
+    expect(snippet.snippetLanguage).toBe("toml");
+    expect(snippet.rootField).toBe("mcp_servers.vibebasket");
+    expect(snippet.snippet).toContain("[mcp_servers.vibebasket]");
+    expect(snippet.snippet).toContain('command = "npx"');
+  });
+
+  it("returns a native YAML snippet for continue", () => {
+    const snippet = getTargetMcpSnippet("continue", "project");
+
+    expect(snippet.snippetLanguage).toBe("yaml");
+    expect(snippet.rootField).toBe("mcpServers");
+    expect(snippet.snippet).toContain("mcpServers:");
+    expect(snippet.snippet).toContain("- name: vibebasket");
+  });
+
+  it("reports unsupported MCP snippet requests honestly", () => {
+    const snippet = getTargetMcpSnippet("github-copilot", "project");
+
+    expect(snippet.supportsMcp).toBe(false);
+    expect(snippet.snippet).toBeNull();
+    expect(snippet.notes[0]).toContain("does not expose MCP");
+  });
+});

--- a/apps/cli/src/services/target-guidance.ts
+++ b/apps/cli/src/services/target-guidance.ts
@@ -1,0 +1,411 @@
+import { TARGET_CAPABILITIES } from "../../../../packages/adapters/src/target-capabilities.js";
+import {
+  getBaseVibeBasketServerDefinition,
+  getLocalVibeBasketMcpSnippet,
+  VIBEBASKET_MCP_SERVER_ID,
+} from "../../../../packages/core/src/local-mcp-snippets.js";
+import type { IdeId, Scope } from "../../../../packages/core/src/manifest.js";
+
+type TargetKind = "editor" | "terminal";
+
+type TargetGuideMetadata = {
+  label: string;
+  vendor: string;
+  kind: TargetKind;
+  note: string;
+  configPathHints: Partial<Record<Scope, string>>;
+  mcpFieldHint?: string;
+  postInstallHint?: string;
+};
+
+const TARGET_GUIDES: Record<IdeId, TargetGuideMetadata> = {
+  antigravity: {
+    label: "Antigravity",
+    vendor: "Google",
+    kind: "editor",
+    note: "Applies through the Gemini Antigravity MCP config path.",
+    configPathHints: {
+      user: "~/.gemini/antigravity/mcp_config.json",
+      project: "<project-root>/.gemini/antigravity/mcp_config.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
+    postInstallHint: "Restart Antigravity or reload the conversation for MCP changes to take effect.",
+  },
+  "claude-code": {
+    label: "Claude Code",
+    vendor: "Anthropic",
+    kind: "terminal",
+    note: "Backed by Claude Code MCP configuration files plus documented skills surfaces.",
+    configPathHints: {
+      user: "~/.claude.json",
+      project: "<project-root>/.claude.json",
+    },
+    mcpFieldHint: "Add a root-level mcpServers.vibebasket entry.",
+    postInstallHint: "Restart Claude Code or reload the session so the MCP server is discovered.",
+  },
+  "cline-cli": {
+    label: "Cline CLI",
+    vendor: "Cline",
+    kind: "terminal",
+    note: "Backed by the Cline CLI MCP settings file.",
+    configPathHints: {
+      user: "~/.cline/data/settings/cline_mcp_settings.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON settings file.",
+    postInstallHint: "Restart Cline CLI or reload its MCP settings after editing the config.",
+  },
+  "deepseek-tui": {
+    label: "DeepSeek-TUI",
+    vendor: "DeepSeek",
+    kind: "terminal",
+    note: "Backed by DeepSeek-TUI MCP configuration.",
+    configPathHints: {
+      user: "~/.deepseek/mcp.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
+    postInstallHint: "Restart DeepSeek-TUI so the MCP server is discovered.",
+  },
+  codex: {
+    label: "Codex CLI",
+    vendor: "OpenAI",
+    kind: "terminal",
+    note: "Backed by user and trusted project Codex config.toml MCP configuration.",
+    configPathHints: {
+      user: "~/.codex/config.toml",
+      project: "<project-root>/.codex/config.toml",
+    },
+    mcpFieldHint: "Add the vibebasket server under Codex's MCP server table in TOML form.",
+    postInstallHint: "Restart Codex CLI or open a new task after editing config.toml.",
+  },
+  continue: {
+    label: "Continue",
+    vendor: "Continue",
+    kind: "editor",
+    note: "Backed by config.yaml MCP configuration plus prompt references.",
+    configPathHints: {
+      user: "~/.continue/config.yaml",
+      project: "<project-root>/.continue/config.yaml",
+    },
+    mcpFieldHint: "Add a vibebasket entry inside Continue's mcpServers YAML list.",
+    postInstallHint: "Restart Continue or reload the extension to pick up MCP changes.",
+  },
+  cursor: {
+    label: "Cursor",
+    vendor: "Cursor",
+    kind: "editor",
+    note: "Backed by native Cursor MCP config plus documented skills and rules directories.",
+    configPathHints: {
+      user: "~/.cursor/mcp.json",
+      project: "<project-root>/.cursor/mcp.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
+    postInstallHint: "Restart Cursor or open a new workspace session after editing the MCP config.",
+  },
+  "gemini-cli": {
+    label: "Gemini CLI",
+    vendor: "Google",
+    kind: "terminal",
+    note: "Backed by Gemini CLI settings plus .gemini/skills discovery.",
+    configPathHints: {
+      user: "~/.gemini/settings.json",
+      project: "<project-root>/.gemini/settings.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in settings.json.",
+    postInstallHint: "Restart Gemini CLI or reopen the session so the MCP server is loaded.",
+  },
+  junie: {
+    label: "JetBrains Junie",
+    vendor: "JetBrains",
+    kind: "editor",
+    note: "Backed by Junie MCP configuration files.",
+    configPathHints: {
+      user: "~/.junie/mcp/mcp.json",
+      project: "<project-root>/.junie/mcp/mcp.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
+    postInstallHint: "Restart Junie CLI or reopen the MCP settings screen to verify activation.",
+  },
+  kiro: {
+    label: "Kiro",
+    vendor: "Kiro",
+    kind: "editor",
+    note: "Backed by Kiro MCP configuration plus documented skills directories.",
+    configPathHints: {
+      user: "~/.kiro/settings/mcp.json",
+      project: "<project-root>/.kiro/settings/mcp.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
+    postInstallHint: "Restart Kiro or reload the workspace after updating MCP config.",
+  },
+  vscode: {
+    label: "VS Code / Cline",
+    vendor: "Microsoft / Cline",
+    kind: "editor",
+    note: "Targets the local Cline extension MCP settings file.",
+    configPathHints: {
+      user: "<VS Code globalStorage>/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
+      project: "<VS Code globalStorage>/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the extension settings JSON.",
+    postInstallHint: "Reload VS Code or restart the Cline extension after editing settings.",
+  },
+  windsurf: {
+    label: "Windsurf",
+    vendor: "Windsurf",
+    kind: "editor",
+    note: "Backed by Windsurf MCP config plus documented skills and rules surfaces.",
+    configPathHints: {
+      user: "~/.codeium/windsurf/mcp_config.json",
+      project: "<project-root>/.codeium/windsurf/mcp_config.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in Windsurf's JSON config.",
+    postInstallHint: "Restart Windsurf or reload the workspace after updating MCP config.",
+  },
+  zed: {
+    label: "Zed",
+    vendor: "Zed Industries",
+    kind: "editor",
+    note: "Backed by Zed context server settings plus documented .agents/skills directories.",
+    configPathHints: {
+      user: "~/.config/zed/settings.json",
+      project: "<project-root>/.zed/settings.json",
+    },
+    mcpFieldHint: "Add a vibebasket entry inside Zed's context_servers block.",
+    postInstallHint: "Restart Zed or reload the context server settings after editing the file.",
+  },
+  roocode: {
+    label: "Roo Code",
+    vendor: "Roo Code",
+    kind: "editor",
+    note: "Backed by project or global Roo MCP config plus Roo-native skills and rules surfaces.",
+    configPathHints: {
+      user: "<VS Code globalStorage>/RooVeterinaryInc.roo-cline/settings/mcp_settings.json",
+      project: "<project-root>/.roo/mcp.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in Roo's MCP settings JSON.",
+    postInstallHint: "Restart Roo Code or reload the project so the new MCP server is discovered.",
+  },
+  hermes: {
+    label: "Hermes",
+    vendor: "Hermes",
+    kind: "terminal",
+    note: "Backed by ~/.hermes/config.yaml MCP configuration and project-level .hermesrules.",
+    configPathHints: {
+      project: "~/.hermes/config.yaml",
+    },
+    mcpFieldHint: "Add a vibebasket block under Hermes mcp_servers in YAML form.",
+    postInstallHint: "Restart Hermes or reload the terminal for configuration changes to take effect.",
+  },
+  openclaw: {
+    label: "OpenClaw",
+    vendor: "OpenClaw",
+    kind: "terminal",
+    note: "Backed by ~/.openclaw/openclaw.json MCP configuration and project-level .openclawrules.",
+    configPathHints: {
+      project: "~/.openclaw/openclaw.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
+    postInstallHint: "Restart OpenClaw after updating the MCP config.",
+  },
+  "github-copilot": {
+    label: "GitHub Copilot",
+    vendor: "GitHub / Microsoft",
+    kind: "editor",
+    note: "Current auto-apply support covers skills and rules only; MCP configuration is not modeled.",
+    configPathHints: {
+      project: ".github/copilot-instructions.md",
+    },
+  },
+  void: {
+    label: "Void Editor",
+    vendor: "Void",
+    kind: "editor",
+    note: "Backed by the official user-scope Void MCP config.",
+    configPathHints: {
+      user: "~/.void-editor/mcp.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
+    postInstallHint: "Restart Void Editor after updating the MCP config.",
+  },
+  aider: {
+    label: "Aider",
+    vendor: "Aider",
+    kind: "terminal",
+    note: "Current auto-apply support covers rules and skills only; MCP configuration is not modeled.",
+    configPathHints: {
+      project: "<project-root>/.aider.conf.yml",
+    },
+  },
+  "cortex-code": {
+    label: "Cortex Code",
+    vendor: "Snowflake",
+    kind: "terminal",
+    note: "Backed by Cortex MCP config plus .cortex/skills.",
+    configPathHints: {
+      user: "~/.snowflake/cortex/mcp.json",
+      project: "<project-root>/.snowflake/cortex/mcp.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
+    postInstallHint: "Restart Cortex Code or reopen the session after editing the MCP config.",
+  },
+  goose: {
+    label: "Goose",
+    vendor: "Block / Linux Foundation",
+    kind: "terminal",
+    note: "Backed by Goose YAML config.",
+    configPathHints: {
+      user: "~/.config/goose/config.yaml",
+    },
+    mcpFieldHint: "Add a vibebasket entry inside the Goose extensions config.",
+    postInstallHint: "Restart Goose or reload the terminal for configuration changes to take effect.",
+  },
+  "ibm-bob": {
+    label: "IBM Bob",
+    vendor: "IBM",
+    kind: "editor",
+    note: "Backed by ~/.bob/mcp_settings.json and project-scoped .bob/mcp.json.",
+    configPathHints: {
+      user: "~/.bob/mcp_settings.json",
+      project: "<project-root>/.bob/mcp.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
+    postInstallHint: "Restart IBM Bob or reload the window for MCP changes to take effect.",
+  },
+  codebuddy: {
+    label: "CodeBuddy",
+    vendor: "Tencent Cloud",
+    kind: "editor",
+    note: "Backed by user and project JSON MCP config.",
+    configPathHints: {
+      user: "~/.codebuddy/.mcp.json",
+      project: "<project-root>/.mcp.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
+    postInstallHint: "Restart CodeBuddy after editing the MCP config.",
+  },
+  opencode: {
+    label: "OpenCode",
+    vendor: "Anomaly",
+    kind: "terminal",
+    note: "Backed by opencode.json plus .opencode skills and AGENTS.md rules.",
+    configPathHints: {
+      user: "~/.config/opencode/opencode.json",
+      project: "<project-root>/opencode.json",
+    },
+    mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
+    postInstallHint: "Restart OpenCode or open a fresh session after updating the config.",
+  },
+};
+
+function buildRecommendedSteps(targetId: IdeId, scope: Scope, supportsMcp: boolean) {
+  if (!supportsMcp) {
+    return [
+      "This target does not expose MCP auto-install support in VibeBasket today.",
+      "Use VibeBasket for skills/rules on this target, or connect VibeBasket MCP from another IDE that supports custom MCP clients.",
+    ];
+  }
+
+  const scopeLabel = scope === "project" ? "project-scoped" : "user-scoped";
+  return [
+    `Add the VibeBasket MCP server entry to the ${scopeLabel} config surface for this target.`,
+    "Restart or reload the target so the new MCP server is discovered.",
+    "Call session.get_state from the connected MCP client before saving stacks or applying changes.",
+  ];
+}
+
+export function listTargetGuides() {
+  return (Object.entries(TARGET_GUIDES) as Array<[IdeId, TargetGuideMetadata]>)
+    .map(([targetId, metadata]) => {
+      const capabilities = TARGET_CAPABILITIES[targetId];
+      return {
+        targetId,
+        label: metadata.label,
+        vendor: metadata.vendor,
+        kind: metadata.kind,
+        note: metadata.note,
+        supportsMcp: capabilities.supportsMcp,
+        supportsSkills: capabilities.supportsSkills,
+        supportsRules: capabilities.supportsRules,
+        supportedScopes: [...capabilities.supportedScopes],
+      };
+    })
+    .sort((left, right) => left.label.localeCompare(right.label));
+}
+
+export function getTargetSetupGuide(targetId: IdeId, scope: Scope = "user") {
+  const metadata = TARGET_GUIDES[targetId];
+  const capabilities = TARGET_CAPABILITIES[targetId];
+
+  if (!metadata || !capabilities) {
+    throw new Error(`Unsupported target: ${targetId}`);
+  }
+
+  const scopeSupported = capabilities.supportedScopes.includes(scope);
+  const configPathHint = metadata.configPathHints[scope] ?? null;
+
+  return {
+    targetId,
+    label: metadata.label,
+    vendor: metadata.vendor,
+    kind: metadata.kind,
+    note: metadata.note,
+    scopeRequested: scope,
+    scopeSupported,
+    supportedScopes: [...capabilities.supportedScopes],
+    supportsMcp: capabilities.supportsMcp,
+    supportsSkills: capabilities.supportsSkills,
+    supportsRules: capabilities.supportsRules,
+    configPathHint,
+    mcpFieldHint: metadata.mcpFieldHint ?? null,
+    vibebasketServer:
+      capabilities.supportsMcp && scopeSupported
+        ? {
+            ...getBaseVibeBasketServerDefinition(),
+            postInstallHint: metadata.postInstallHint ?? "Restart the client after updating its MCP config.",
+          }
+        : null,
+    recommendedSteps: buildRecommendedSteps(targetId, scope, capabilities.supportsMcp && scopeSupported),
+  };
+}
+
+export function getTargetMcpSnippet(targetId: IdeId, scope: Scope = "user") {
+  const metadata = TARGET_GUIDES[targetId];
+  const capabilities = TARGET_CAPABILITIES[targetId];
+
+  if (!metadata || !capabilities) {
+    throw new Error(`Unsupported target: ${targetId}`);
+  }
+
+  const scopeSupported = capabilities.supportedScopes.includes(scope);
+  const configPathHint = metadata.configPathHints[scope] ?? null;
+  const renderer =
+    capabilities.supportsMcp && scopeSupported ? getLocalVibeBasketMcpSnippet(targetId) : null;
+
+  return {
+    targetId,
+    label: metadata.label,
+    vendor: metadata.vendor,
+    scopeRequested: scope,
+    scopeSupported,
+    supportedScopes: [...capabilities.supportedScopes],
+    supportsMcp: capabilities.supportsMcp,
+    configPathHint,
+    snippetLanguage: renderer?.format ?? null,
+    rootField: renderer?.rootField ?? null,
+    snippetIsFragment: renderer !== null,
+    mergeStrategyNote: renderer?.mergeStrategyNote ?? null,
+    snippet: renderer?.snippet ?? null,
+    vibebasketServer: renderer !== null ? getBaseVibeBasketServerDefinition() : null,
+    postInstallHint: metadata.postInstallHint ?? null,
+    notes:
+      renderer !== null
+        ? [
+            "This is a merge fragment, not a whole config file.",
+            "Preserve existing user config and only add the vibebasket server entry.",
+          ]
+        : [
+            "This target does not expose MCP auto-install support in VibeBasket today.",
+            "Use another MCP-capable client when you want to access the local VibeBasket MCP server.",
+          ],
+  };
+}

--- a/apps/web/e2e/ui.spec.ts
+++ b/apps/web/e2e/ui.spec.ts
@@ -113,6 +113,26 @@ test.describe("UI — Responsive Breakpoints", () => {
     const desktopSidebar = page.locator("aside");
     await expect(desktopSidebar).toBeVisible({ timeout: 10000 });
   });
+
+  test("docs MCP snippet preview switches targets without overflow", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/en/docs?tab=mcp");
+
+    await expect(page.getByRole("heading", { name: "Native config snippets" })).toBeVisible({
+      timeout: 10000,
+    });
+
+    await page.getByRole("button", { name: "Codex CLI / TOML" }).click();
+    await expect(page.getByText("[mcp_servers.vibebasket]")).toBeVisible({ timeout: 5000 });
+
+    await page.getByRole("button", { name: "Continue / YAML" }).click();
+    await expect(page.getByText("mcpServers:")).toBeVisible({ timeout: 5000 });
+
+    const overflowX = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth + 1,
+    );
+    expect(overflowX).toBe(false);
+  });
 });
 
 test.describe("UI — Accessibility", () => {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -16,8 +16,8 @@ export default defineConfig({
     ? undefined
     : {
         command: process.env.PLAYWRIGHT_PREBUILT
-          ? `${playwrightEnvPrefix} HOSTNAME=127.0.0.1 PORT=${playwrightPort} ${nodeExecPath} .next/standalone/apps/web/server.js`
-          : `${playwrightEnvPrefix} ${nodeExecPath} ../../scripts/run-next.mjs build --webpack && ${playwrightEnvPrefix} HOSTNAME=127.0.0.1 PORT=${playwrightPort} ${nodeExecPath} .next/standalone/apps/web/server.js`,
+          ? `${playwrightEnvPrefix} HOSTNAME=127.0.0.1 PORT=${playwrightPort} ${nodeExecPath} ../../scripts/run-next.mjs start`
+          : `${playwrightEnvPrefix} ${nodeExecPath} ../../scripts/run-next.mjs build --webpack && ${playwrightEnvPrefix} HOSTNAME=127.0.0.1 PORT=${playwrightPort} ${nodeExecPath} ../../scripts/run-next.mjs start`,
         url: playwrightBaseUrl,
         reuseExistingServer: true,
         timeout: 120_000,

--- a/apps/web/src/app/[locale]/docs/page.tsx
+++ b/apps/web/src/app/[locale]/docs/page.tsx
@@ -19,6 +19,7 @@ import { DocsTabCli } from "../../docs/tabs/DocsTabCli";
 import { DocsTabDelimiters } from "../../docs/tabs/DocsTabDelimiters";
 import { DocsTabGettingStarted } from "../../docs/tabs/DocsTabGettingStarted";
 import { DocsTabHub } from "../../docs/tabs/DocsTabHub";
+import { DocsTabMcp } from "../../docs/tabs/DocsTabMcp";
 import { DocsTabSecurity } from "../../docs/tabs/DocsTabSecurity";
 import { DocsTabSelfHosting } from "../../docs/tabs/DocsTabSelfHosting";
 
@@ -50,6 +51,8 @@ export async function generateMetadata({
       ? docs.metadataGettingStarted
       : tab === "cli"
         ? docs.metadataCli
+        : tab === "mcp"
+          ? docs.metadataMcp
         : tab === "adapters"
           ? docs.metadataAdapters
           : tab === "delimiters"
@@ -113,6 +116,7 @@ export default async function LocalizedDocsPage({
     "hub",
     "getting-started",
     "cli",
+    "mcp",
     "adapters",
     "delimiters",
     "security",
@@ -144,6 +148,15 @@ export default async function LocalizedDocsPage({
       tabKey: "cli",
       keywords:
         "cli terminal command apply install dry-run force no-verify scope deploy reference documentation configuration",
+    },
+    {
+      title: docs.guideCards.mcp.title,
+      description: docs.guideCards.mcp.description,
+      icon: <TerminalSquare className="h-5 w-5 text-[#a0fdda]" />,
+      linkText: docs.guideCards.mcp.linkText,
+      tabKey: "mcp",
+      keywords:
+        "mcp model context protocol stdio local server ide integration target guide install planning apply rollback stack",
     },
     {
       title: docs.guideCards.adapters.title,
@@ -201,6 +214,7 @@ export default async function LocalizedDocsPage({
     hub: docs.shell.documentationHub,
     "getting-started": docs.shell.tabs.gettingStarted,
     cli: docs.shell.tabs.cli,
+    mcp: docs.shell.tabs.mcp,
     adapters: docs.shell.tabs.adapters,
     delimiters: docs.shell.tabs.delimiters,
     security: docs.shell.tabs.security,
@@ -357,6 +371,7 @@ export default async function LocalizedDocsPage({
             ) : null}
             {activeTab === "getting-started" ? <DocsTabGettingStarted locale={locale} /> : null}
             {activeTab === "cli" ? <DocsTabCli locale={locale} /> : null}
+            {activeTab === "mcp" ? <DocsTabMcp locale={locale} /> : null}
             {activeTab === "adapters" ? <DocsTabAdapters locale={locale} /> : null}
             {activeTab === "delimiters" ? <DocsTabDelimiters locale={locale} /> : null}
             {activeTab === "security" ? <DocsTabSecurity locale={locale} /> : null}

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -324,7 +324,7 @@ export default async function LocalizedHomePage({
                 {shared.navigation.startBuildingFree}
               </a>
               <a
-                href={`#${sectionIds.catalog}`}
+                href={localizePath(locale, "/docs?tab=mcp")}
                 className="inline-flex h-11 items-center justify-center gap-2 border border-border/80 bg-card/70 px-4 font-mono text-[10px] uppercase tracking-[0.16em] text-foreground transition-colors hover:border-accent/40 hover:text-accent sm:h-12 sm:px-5 sm:text-[11px] sm:tracking-[0.18em]"
               >
                 <TerminalSquare className="h-4 w-4" />

--- a/apps/web/src/app/api/catalog/item/[id]/route.ts
+++ b/apps/web/src/app/api/catalog/item/[id]/route.ts
@@ -1,0 +1,54 @@
+import { checkRateLimit, getClientAddress } from "@/lib/rate-limit";
+import { applySecurityHeaders, createTooManyRequestsResponse } from "@/lib/security-headers";
+import { catalogItems, db, eq } from "@vibebasket/core";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+const ITEM_RATE_LIMIT = 120;
+const ITEM_RATE_WINDOW_MS = 60 * 1000;
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const rateLimit = checkRateLimit(
+    `catalog-item:${getClientAddress(request)}`,
+    ITEM_RATE_LIMIT,
+    ITEM_RATE_WINDOW_MS,
+  );
+  if (!rateLimit.allowed) {
+    return createTooManyRequestsResponse(rateLimit.retryAfterSeconds);
+  }
+
+  try {
+    const { id } = await context.params;
+    const rows = await db
+      .select({
+        id: catalogItems.id,
+        type: catalogItems.type,
+        displayName: catalogItems.displayName,
+        description: catalogItems.description,
+        sourceName: catalogItems.sourceName,
+        sourceUrl: catalogItems.sourceUrl,
+        verified: catalogItems.verified,
+        official: catalogItems.official,
+        lastSyncedAt: catalogItems.lastSyncedAt,
+        data: catalogItems.data,
+      })
+      .from(catalogItems)
+      .where(eq(catalogItems.id, id))
+      .limit(1);
+
+    if (!rows[0]) {
+      return applySecurityHeaders(NextResponse.json({ error: "Catalog item not found." }, { status: 404 }));
+    }
+
+    return applySecurityHeaders(NextResponse.json(rows[0]));
+  } catch (error) {
+    console.error("Failed to fetch catalog item:", error);
+    return applySecurityHeaders(
+      NextResponse.json({ error: "Failed to fetch catalog item." }, { status: 500 }),
+    );
+  }
+}

--- a/apps/web/src/app/docs/tabs/DocsTabCli.tsx
+++ b/apps/web/src/app/docs/tabs/DocsTabCli.tsx
@@ -41,6 +41,8 @@ const CLI_COPY = {
       "Diagnoses the local environment: checks for .vibebasket project structure, inspects adapter config presence, reports MCP counts where readable, and prints a concise environment summary for the current machine.",
     rollbackDescription:
       "Opens an interactive restore flow, lets you choose from recent timestamped backups, and then restores the selected adapter config snapshot. For project-scoped backups, run it from the same project root you want to restore into.",
+    mcpServeDescription:
+      "Runs the local stdio VibeBasket MCP server. This is the IDE-facing surface for catalog search, target guidance, install planning, bundle apply, backup inspection, rollback, and local stack save/load. Cloud stack save is still intentionally routed through the website today.",
   },
   tr: {
     title: "CLI Referansı",
@@ -78,6 +80,8 @@ const CLI_COPY = {
       "Yerel ortamı teşhis eder: .vibebasket proje yapısını kontrol eder, adaptör config varlığını inceler, okunabildiğinde MCP sayılarını raporlar ve mevcut makine için kısa bir ortam özeti yazdırır.",
     rollbackDescription:
       "Etkileşimli bir geri yükleme akışı açar, son zaman damgalı yedeklerden seçim yapmanı sağlar ve ardından seçilen adaptör config anlık görüntüsünü geri yükler. Proje kapsamlı yedeklerde, geri yüklemek istediğin aynı proje kökünden çalıştır.",
+    mcpServeDescription:
+      "Yerel stdio VibeBasket MCP sunucusunu çalıştırır. Bu yüzey IDE tarafında katalog arama, hedef rehberliği, kurulum planlama, bundle apply, yedek inceleme, rollback ve yerel stack kaydetme/yükleme için kullanılır. Cloud stack save ise bugün kasıtlı olarak hâlâ web sitesi üzerinden yürür.",
   },
   es: {
     title: "Referencia CLI",
@@ -115,6 +119,8 @@ const CLI_COPY = {
       "Diagnostica el entorno local: comprueba la estructura del proyecto .vibebasket, inspecciona la presencia de configuración del adaptador, informa cantidades MCP cuando son legibles y muestra un resumen conciso del entorno de la máquina actual.",
     rollbackDescription:
       "Abre un flujo interactivo de restauración, te permite elegir entre backups recientes con marca temporal y luego restaura la instantánea de configuración del adaptador seleccionada. Para backups con alcance de proyecto, ejecútalo desde la misma raíz de proyecto que quieras restaurar.",
+    mcpServeDescription:
+      "Ejecuta el servidor MCP local de VibeBasket sobre stdio. Es la superficie orientada al IDE para búsqueda de catálogo, guía de objetivos, planificación de instalación, apply de bundles, inspección de backups, rollback y guardado/carga de stacks locales. El guardado cloud de stacks sigue pasando por el sitio web por diseño.",
   },
   zh: {
     title: "CLI 参考",
@@ -150,6 +156,8 @@ const CLI_COPY = {
       "诊断本地环境：检查 .vibebasket 项目结构，探测 adapter 配置是否存在，在可读取时报告 MCP 数量，并输出当前机器的简明环境摘要。",
     rollbackDescription:
       "打开交互式恢复流程，让你从最近带时间戳的备份中进行选择，然后恢复选定的 adapter 配置快照。对于 project 范围的备份，请从你想恢复的同一个项目根目录中运行它。",
+    mcpServeDescription:
+      "运行本地 stdio VibeBasket MCP 服务。这是面向 IDE 的入口，用于目录搜索、目标指导、安装规划、bundle apply、备份检查、rollback，以及本地 stack 的保存与加载。Cloud stack save 目前仍刻意保留在网站路径中。",
   },
   hi: {
     title: "CLI संदर्भ",
@@ -186,6 +194,8 @@ const CLI_COPY = {
       "Local environment का diagnostics करता है: .vibebasket project structure जाँचता है, adapter config presence देखता है, पढ़े जा सकने पर MCP counts रिपोर्ट करता है, और current machine के लिए concise environment summary प्रिंट करता है।",
     rollbackDescription:
       "Interactive restore flow खोलता है, हाल के timestamped backups में से चुनने देता है, और फिर चुना गया adapter config snapshot restore करता है। Project-scoped backups के लिए इसे उसी project root से चलाएँ जहाँ restore करना है।",
+    mcpServeDescription:
+      "Local stdio VibeBasket MCP server चलाता है। यही IDE-facing surface catalog search, target guidance, install planning, bundle apply, backup inspection, rollback और local stack save/load के लिए उपयोग होती है। Cloud stack save अभी भी जानबूझकर website path पर रखा गया है।",
   },
   ru: {
     title: "Справочник CLI",
@@ -223,6 +233,8 @@ const CLI_COPY = {
       "Диагностирует локальную среду: проверяет структуру проекта .vibebasket, наличие конфигов адаптеров, при возможности считает MCP и печатает краткую сводку окружения для текущей машины.",
     rollbackDescription:
       "Открывает интерактивный restore flow, позволяет выбрать один из недавних backup’ов с timestamp и затем восстанавливает выбранный snapshot конфигурации адаптера. Для project-scoped backup’ов запускайте команду из того же корня проекта, который хотите восстановить.",
+    mcpServeDescription:
+      "Запускает локальный stdio MCP-сервер VibeBasket. Это IDE-facing поверхность для поиска по каталогу, guidance по целям, планирования установки, apply bundle’ов, проверки backup’ов, rollback и локального сохранения/загрузки stack’ов. Cloud stack save по-прежнему намеренно оставлен за сайтом.",
   },
 } as const;
 
@@ -399,6 +411,14 @@ export function DocsTabCli({ locale }: { locale: AppLocale }) {
             </h3>
             <p className="text-sm text-[#bdc9c2] leading-relaxed max-w-3xl">
               {copy.rollbackDescription}
+            </p>
+          </div>
+          <div className="border border-[#3e4944] p-6">
+            <h3 className="font-mono text-[#a0fdda] text-xs font-semibold mb-3">
+              vibebasket mcp serve
+            </h3>
+            <p className="text-sm text-[#bdc9c2] leading-relaxed max-w-3xl">
+              {copy.mcpServeDescription}
             </p>
           </div>
         </div>

--- a/apps/web/src/app/docs/tabs/DocsTabMcp.test.tsx
+++ b/apps/web/src/app/docs/tabs/DocsTabMcp.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { DocsTabMcp } from "./DocsTabMcp";
+
+describe("DocsTabMcp", () => {
+  it("renders native snippet examples for representative targets", () => {
+    const html = renderToStaticMarkup(<DocsTabMcp locale="en" />);
+
+    expect(html).toContain("Native config snippets");
+    expect(html).toContain("Cursor / JSON");
+    expect(html).toContain("Claude Code / JSON");
+    expect(html).toContain("Continue / YAML");
+    expect(html).toContain("Codex CLI / TOML");
+    expect(html).toContain("&quot;mcpServers&quot;");
+  });
+});

--- a/apps/web/src/app/docs/tabs/DocsTabMcp.tsx
+++ b/apps/web/src/app/docs/tabs/DocsTabMcp.tsx
@@ -1,0 +1,391 @@
+import type { AppLocale } from "@/i18n/config";
+import { localizePath } from "@/i18n/locale-routing";
+import { McpSnippetPreview } from "@/components/docs/McpSnippetPreview";
+import { ShieldCheck, TerminalSquare, Wrench } from "lucide-react";
+import Link from "next/link";
+
+const MCP_COPY = {
+  en: {
+    title: "Local MCP",
+    intro:
+      "VibeBasket exposes a local stdio MCP server through the CLI so AI IDEs can discover catalog items, understand target capabilities, plan installs, and apply bundles without leaving the conversation.",
+    docsHome: "Docs",
+    statusTitle: "What it does today",
+    statusBody:
+      "This is a strong phase-1 MCP surface: catalog search, item lookup, target guidance, install planning, install apply, backup listing, rollback, and local stack save/load all run through the real CLI service layer.",
+    commandTitle: "Start command",
+    commandBody:
+      "Run the MCP server locally with npx vibebasket mcp serve. The client should connect over stdio, not HTTP.",
+    snippetsTitle: "Native config snippets",
+    snippetsBody:
+      "Ask the local MCP for target-native fragments with targets.get_mcp_snippet. These examples show the exact merge shape for a few representative clients.",
+    snippetsFootnote:
+      "Each snippet is a merge fragment, not a complete config file. Preserve the rest of the user's config.",
+    cursorExample: "Cursor / JSON",
+    continueExample: "Continue / YAML",
+    codexExample: "Codex CLI / TOML",
+    claudeCodeExample: "Claude Code / JSON",
+    zedExample: "Zed / JSON",
+    gooseExample: "Goose / YAML",
+    toolsTitle: "Key tools",
+    tools: [
+      "session.get_state — discover current API base URL, write policy, and local/cloud stack availability",
+      "targets.list / targets.get_setup_guide / targets.get_mcp_snippet — inspect target capabilities, setup guidance, and native MCP config fragments for each IDE",
+      "catalog.search / catalog.get_item — search and inspect trusted catalog entries",
+      "install.plan / install.apply — dry-run first, then apply through the real adapter pipeline",
+      "install.list_backups / install.rollback — inspect and restore local backups",
+    ],
+    safetyTitle: "Safety model",
+    safetyBody:
+      "Low-risk tools run directly. Medium- and high-risk tools are policy-gated. Runtime secrets stay local, and the MCP surface does not pretend cloud stack save is linked when it is not.",
+    limitationsTitle: "Current limitations",
+    limitations: [
+      "Cloud/profile-backed stack save is still handled on the website, not inside local MCP.",
+      "The MCP server is stdio-only in this phase.",
+      "Target guidance is intentionally conservative and follows the current adapter-backed install model.",
+    ],
+    nextStep:
+      "Open the CLI reference if you want the full command surface, or jump back to the catalog to build a bundle first.",
+    openCli: "Open CLI reference",
+    openCatalog: "Open catalog",
+  },
+  tr: {
+    title: "Yerel MCP",
+    intro:
+      "VibeBasket, CLI üzerinden yerel bir stdio MCP sunucusu açar; böylece AI IDE’ler katalog öğelerini keşfedebilir, hedef yeteneklerini anlayabilir, kurulum planı çıkarabilir ve konuşmadan çıkmadan bundle uygulayabilir.",
+    docsHome: "Dokümanlar",
+    statusTitle: "Bugün neler yapıyor",
+    statusBody:
+      "Bu güçlü bir phase-1 MCP yüzeyi: katalog arama, öğe inceleme, hedef rehberliği, kurulum planlama, kurulum uygulama, yedek listeleme, rollback ve yerel stack kaydetme/yükleme doğrudan gerçek CLI servis katmanı üzerinden çalışır.",
+    commandTitle: "Başlatma komutu",
+    commandBody:
+      "MCP sunucusunu yerelde npx vibebasket mcp serve ile çalıştır. İstemci HTTP değil stdio üzerinden bağlanmalı.",
+    snippetsTitle: "Native config snippet'leri",
+    snippetsBody:
+      "Yerel MCP'den targets.get_mcp_snippet ile hedefe özel fragment'ler iste. Bu örnekler birkaç temsili istemci için tam merge şeklini gösterir.",
+    snippetsFootnote:
+      "Her snippet tam config dosyası değil, merge fragment'tir. Kullanıcının mevcut config'inin geri kalanını koru.",
+    cursorExample: "Cursor / JSON",
+    continueExample: "Continue / YAML",
+    codexExample: "Codex CLI / TOML",
+    claudeCodeExample: "Claude Code / JSON",
+    zedExample: "Zed / JSON",
+    gooseExample: "Goose / YAML",
+    toolsTitle: "Temel araçlar",
+    tools: [
+      "session.get_state — mevcut API base URL, write policy ve local/cloud stack durumunu öğrenir",
+      "targets.list / targets.get_setup_guide / targets.get_mcp_snippet — hedef yeteneklerini, kurulum rehberini ve her IDE için native MCP config fragment'lerini gösterir",
+      "catalog.search / catalog.get_item — güvenilir katalog kayıtlarını arar ve inceler",
+      "install.plan / install.apply — önce dry-run plan, sonra gerçek adaptör hattı üzerinden apply",
+      "install.list_backups / install.rollback — yerel yedekleri inceler ve geri yükler",
+    ],
+    safetyTitle: "Güvenlik modeli",
+    safetyBody:
+      "Düşük riskli araçlar doğrudan çalışır. Orta ve yüksek riskli araçlar policy ile korunur. Runtime secret’lar yerelde kalır ve MCP yüzeyi, cloud stack save bağlı değilse bunu varmış gibi göstermez.",
+    limitationsTitle: "Mevcut sınırlamalar",
+    limitations: [
+      "Cloud/profile-backed stack save hâlâ local MCP içinde değil, web sitesi üzerinden yürür.",
+      "Bu fazda MCP sunucusu yalnızca stdio çalışır.",
+      "Target guidance kasıtlı olarak konservatiftir ve mevcut adaptör destekli kurulum modelini takip eder.",
+    ],
+    nextStep:
+      "Tüm komut yüzeyi için CLI referansını açabilir ya da önce bir bundle oluşturmak için kataloğa dönebilirsin.",
+    openCli: "CLI referansını aç",
+    openCatalog: "Kataloğu aç",
+  },
+  es: {
+    title: "MCP local",
+    intro:
+      "VibeBasket expone un servidor MCP local por stdio desde el CLI para que los AI IDEs descubran elementos del catálogo, entiendan capacidades por objetivo, planifiquen instalaciones y apliquen bundles sin salir de la conversación.",
+    docsHome: "Docs",
+    statusTitle: "Lo que hace hoy",
+    statusBody:
+      "Es una buena superficie MCP de fase 1: búsqueda de catálogo, lookup por id, guía por objetivo, planificación, apply, listado de backups, rollback y guardado/carga de stacks locales pasan por la misma capa real de servicios del CLI.",
+    commandTitle: "Comando de arranque",
+    commandBody:
+      "Ejecuta el servidor MCP local con npx vibebasket mcp serve. El cliente debe conectarse por stdio, no por HTTP.",
+    snippetsTitle: "Snippets nativos de configuración",
+    snippetsBody:
+      "Pide fragmentos nativos por objetivo con targets.get_mcp_snippet. Estos ejemplos muestran la forma exacta de merge para algunos clientes representativos.",
+    snippetsFootnote:
+      "Cada snippet es un fragmento de merge, no un archivo de configuración completo. Conserva el resto de la configuración del usuario.",
+    cursorExample: "Cursor / JSON",
+    continueExample: "Continue / YAML",
+    codexExample: "Codex CLI / TOML",
+    claudeCodeExample: "Claude Code / JSON",
+    zedExample: "Zed / JSON",
+    gooseExample: "Goose / YAML",
+    toolsTitle: "Herramientas clave",
+    tools: [
+      "session.get_state — descubre la API base URL actual, la política de escritura y la disponibilidad de stacks locales/cloud",
+      "targets.list / targets.get_setup_guide / targets.get_mcp_snippet — inspecciona capacidades por objetivo, guía de integración y fragmentos nativos de configuración MCP por IDE",
+      "catalog.search / catalog.get_item — busca e inspecciona entradas confiables del catálogo",
+      "install.plan / install.apply — primero dry-run, luego apply por la tubería real de adapters",
+      "install.list_backups / install.rollback — inspecciona y restaura backups locales",
+    ],
+    safetyTitle: "Modelo de seguridad",
+    safetyBody:
+      "Las herramientas de bajo riesgo corren directamente. Las de riesgo medio o alto quedan protegidas por policy. Los secrets de runtime permanecen locales y la superficie MCP no finge que el guardado cloud está enlazado cuando no lo está.",
+    limitationsTitle: "Limitaciones actuales",
+    limitations: [
+      "El guardado cloud/profile-backed de stacks sigue yendo por el sitio web, no por el MCP local.",
+      "En esta fase el servidor MCP es solo stdio.",
+      "La guía por objetivo es conservadora y sigue el modelo actual respaldado por adapters.",
+    ],
+    nextStep:
+      "Abre la referencia del CLI si quieres toda la superficie de comandos, o vuelve al catálogo para construir primero un bundle.",
+    openCli: "Abrir referencia CLI",
+    openCatalog: "Abrir catálogo",
+  },
+  zh: {
+    title: "本地 MCP",
+    intro:
+      "VibeBasket 通过 CLI 暴露一个本地 stdio MCP 服务，让 AI IDE 可以在不离开对话的情况下发现目录条目、理解目标能力、规划安装并应用 bundle。",
+    docsHome: "文档",
+    statusTitle: "当前能力",
+    statusBody:
+      "这是一个扎实的 phase-1 MCP 面：目录搜索、单项查询、目标指导、安装规划、应用、备份列表、rollback，以及本地 stack 的保存与加载，都复用了真实的 CLI 服务层。",
+    commandTitle: "启动命令",
+    commandBody: "使用 npx vibebasket mcp serve 在本地启动 MCP 服务。客户端应通过 stdio 连接，而不是 HTTP。",
+    snippetsTitle: "原生配置片段",
+    snippetsBody:
+      "通过 targets.get_mcp_snippet 请求目标原生片段。下面这些示例展示了几个代表性客户端的准确 merge 形状。",
+    snippetsFootnote:
+      "每个 snippet 都是 merge 片段，不是完整配置文件。请保留用户现有配置的其余部分。",
+    cursorExample: "Cursor / JSON",
+    continueExample: "Continue / YAML",
+    codexExample: "Codex CLI / TOML",
+    claudeCodeExample: "Claude Code / JSON",
+    zedExample: "Zed / JSON",
+    gooseExample: "Goose / YAML",
+    toolsTitle: "关键工具",
+    tools: [
+      "session.get_state — 查看当前 API base URL、写策略与本地/云 stack 可用性",
+      "targets.list / targets.get_setup_guide / targets.get_mcp_snippet — 查看目标能力、接入指导与每个 IDE 的原生 MCP 配置片段",
+      "catalog.search / catalog.get_item — 搜索并查看可信目录条目",
+      "install.plan / install.apply — 先 dry-run，再通过真实 adapter 管线 apply",
+      "install.list_backups / install.rollback — 查看并恢复本地备份",
+    ],
+    safetyTitle: "安全模型",
+    safetyBody:
+      "低风险工具可直接运行。中高风险工具受 policy 保护。Runtime secrets 保持在本机，本地 MCP 也不会假装 cloud stack save 已接通。",
+    limitationsTitle: "当前限制",
+    limitations: [
+      "Cloud/profile-backed stack save 仍在网站路径中，不在本地 MCP 内。",
+      "当前阶段 MCP 服务仅支持 stdio。",
+      "目标指导刻意保持保守，遵循当前 adapter 支持的安装模型。",
+    ],
+    nextStep: "如果你想看完整命令面，请打开 CLI 文档；或者先回到目录构建一个 bundle。",
+    openCli: "打开 CLI 文档",
+    openCatalog: "打开目录",
+  },
+  hi: {
+    title: "लोकल MCP",
+    intro:
+      "VibeBasket CLI के माध्यम से एक local stdio MCP server देता है, ताकि AI IDEs catalog items खोज सकें, target capabilities समझ सकें, install plan बना सकें, और conversation छोड़े बिना bundles apply कर सकें.",
+    docsHome: "दस्तावेज़",
+    statusTitle: "यह अभी क्या करता है",
+    statusBody:
+      "यह एक मजबूत phase-1 MCP surface है: catalog search, single item lookup, target guidance, install planning, apply, backup listing, rollback, और local stack save/load सब वास्तविक CLI service layer से चलते हैं.",
+    commandTitle: "शुरू करने का command",
+    commandBody:
+      "Local MCP server को npx vibebasket mcp serve से चलाएँ। Client को HTTP नहीं, stdio के माध्यम से connect करना चाहिए.",
+    snippetsTitle: "Native config snippets",
+    snippetsBody:
+      "targets.get_mcp_snippet से target-native fragments माँगें। ये examples कुछ representative clients के लिए exact merge shape दिखाते हैं.",
+    snippetsFootnote:
+      "हर snippet एक merge fragment है, पूरा config file नहीं। User की बाकी config को सुरक्षित रखें.",
+    cursorExample: "Cursor / JSON",
+    continueExample: "Continue / YAML",
+    codexExample: "Codex CLI / TOML",
+    claudeCodeExample: "Claude Code / JSON",
+    zedExample: "Zed / JSON",
+    gooseExample: "Goose / YAML",
+    toolsTitle: "मुख्य tools",
+    tools: [
+      "session.get_state — current API base URL, write policy और local/cloud stack availability दिखाता है",
+      "targets.list / targets.get_setup_guide / targets.get_mcp_snippet — target capabilities, setup guidance और हर IDE के लिए native MCP config fragments बताता है",
+      "catalog.search / catalog.get_item — trusted catalog entries खोजता और दिखाता है",
+      "install.plan / install.apply — पहले dry-run, फिर real adapter pipeline के माध्यम से apply",
+      "install.list_backups / install.rollback — local backups दिखाता और restore करता है",
+    ],
+    safetyTitle: "सुरक्षा मॉडल",
+    safetyBody:
+      "Low-risk tools सीधे चलते हैं। Medium और high-risk tools policy-gated हैं। Runtime secrets local रहते हैं, और MCP surface cloud stack save linked न होने पर उसका दिखावा नहीं करता.",
+    limitationsTitle: "मौजूदा सीमाएँ",
+    limitations: [
+      "Cloud/profile-backed stack save अभी भी website के रास्ते चलता है, local MCP के अंदर नहीं.",
+      "इस phase में MCP server केवल stdio है.",
+      "Target guidance जानबूझकर conservative है और current adapter-backed install model को follow करती है.",
+    ],
+    nextStep:
+      "पूरी command surface के लिए CLI reference खोलें, या पहले bundle बनाने के लिए catalog पर लौटें.",
+    openCli: "CLI reference खोलें",
+    openCatalog: "कैटलॉग खोलें",
+  },
+  ru: {
+    title: "Локальный MCP",
+    intro:
+      "VibeBasket через CLI поднимает локальный stdio MCP-сервер, чтобы AI IDE могли искать элементы каталога, понимать возможности целей, планировать установку и применять bundle, не выходя из диалога.",
+    docsHome: "Документация",
+    statusTitle: "Что умеет сейчас",
+    statusBody:
+      "Это сильная phase-1 MCP-поверхность: поиск по каталогу, lookup по item id, guidance по целям, планирование, apply, список backup’ов, rollback и локальное сохранение/загрузка stack’ов идут через реальный сервисный слой CLI.",
+    commandTitle: "Команда запуска",
+    commandBody:
+      "Запускайте локальный MCP-сервер командой npx vibebasket mcp serve. Клиент должен подключаться по stdio, а не по HTTP.",
+    snippetsTitle: "Нативные config snippets",
+    snippetsBody:
+      "Запрашивайте target-native fragments через targets.get_mcp_snippet. Эти примеры показывают точную merge-форму для нескольких типовых клиентов.",
+    snippetsFootnote:
+      "Каждый snippet — это merge fragment, а не полный config file. Сохраняйте остальную пользовательскую конфигурацию.",
+    cursorExample: "Cursor / JSON",
+    continueExample: "Continue / YAML",
+    codexExample: "Codex CLI / TOML",
+    claudeCodeExample: "Claude Code / JSON",
+    zedExample: "Zed / JSON",
+    gooseExample: "Goose / YAML",
+    toolsTitle: "Ключевые tools",
+    tools: [
+      "session.get_state — показывает текущий API base URL, write policy и доступность local/cloud stack’ов",
+      "targets.list / targets.get_setup_guide / targets.get_mcp_snippet — показывает возможности целей, guidance по настройке и нативные MCP config fragments для каждого IDE",
+      "catalog.search / catalog.get_item — ищет и показывает доверенные записи каталога",
+      "install.plan / install.apply — сначала dry-run, затем apply через реальный adapter pipeline",
+      "install.list_backups / install.rollback — показывает и восстанавливает локальные backup’ы",
+    ],
+    safetyTitle: "Модель безопасности",
+    safetyBody:
+      "Low-risk tools запускаются напрямую. Medium- и high-risk tools проходят через policy. Runtime secrets остаются локальными, а MCP-поверхность не делает вид, что cloud stack save уже привязан, если это не так.",
+    limitationsTitle: "Текущие ограничения",
+    limitations: [
+      "Cloud/profile-backed stack save по-прежнему идёт через сайт, а не через local MCP.",
+      "На этой фазе MCP-сервер работает только по stdio.",
+      "Guidance по целям намеренно консервативен и следует текущей adapter-backed модели установки.",
+    ],
+    nextStep:
+      "Откройте CLI reference, если нужен весь набор команд, или вернитесь в каталог, чтобы сначала собрать bundle.",
+    openCli: "Открыть CLI reference",
+    openCatalog: "Открыть каталог",
+  },
+} as const;
+
+const EXAMPLE_TARGETS = [
+  { key: "cursorExample", targetId: "cursor" },
+  { key: "claudeCodeExample", targetId: "claude-code" },
+  { key: "continueExample", targetId: "continue" },
+  { key: "codexExample", targetId: "codex" },
+  { key: "zedExample", targetId: "zed" },
+  { key: "gooseExample", targetId: "goose" },
+] as const;
+
+export function DocsTabMcp({ locale }: { locale: AppLocale }) {
+  const copy = MCP_COPY[locale as keyof typeof MCP_COPY] ?? MCP_COPY.en;
+
+  return (
+    <div className="animate-in fade-in slide-in-from-bottom-4 duration-300">
+      <div className="mb-12 flex flex-wrap items-center gap-2 break-words font-mono text-[10px] uppercase tracking-widest text-[#a0fdda] select-none">
+        <Link
+          href={localizePath(locale, "/docs")}
+          className="opacity-80 transition-colors hover:text-[#a0fdda]"
+        >
+          {copy.docsHome}
+        </Link>
+        <span className="text-[#bdc9c2]/30">/</span>
+        <span className="text-foreground">{copy.title}</span>
+      </div>
+
+      <div className="mb-20">
+        <h1 className="mb-8 text-4xl font-bold tracking-tight text-foreground sm:text-6xl">
+          {copy.title}
+        </h1>
+        <p className="max-w-3xl text-base leading-relaxed text-[#bdc9c2] sm:text-lg">
+          {copy.intro}
+        </p>
+      </div>
+
+      <div className="space-y-10">
+        <section className="border border-[#3e4944] bg-[#181d1a] p-6 sm:p-8">
+          <div className="mb-4 flex items-center gap-3">
+            <TerminalSquare className="h-5 w-5 text-[#a0fdda]" />
+            <h2 className="text-xl font-semibold text-foreground">{copy.commandTitle}</h2>
+          </div>
+          <code className="mb-4 block overflow-x-auto border border-[#3e4944] bg-[#101412] px-4 py-3 font-mono text-sm text-[#a0fdda]">
+            npx vibebasket mcp serve
+          </code>
+          <p className="text-sm leading-relaxed text-[#bdc9c2]">{copy.commandBody}</p>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-2">
+          <div className="border border-[#3e4944] bg-[#181d1a] p-6 sm:p-8">
+            <div className="mb-4 flex items-center gap-3">
+              <Wrench className="h-5 w-5 text-[#33bbc5]" />
+              <h2 className="text-xl font-semibold text-foreground">{copy.statusTitle}</h2>
+            </div>
+            <p className="mb-5 text-sm leading-relaxed text-[#bdc9c2]">{copy.statusBody}</p>
+            <h3 className="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-[#a0fdda]">
+              {copy.toolsTitle}
+            </h3>
+            <ul className="space-y-3 text-sm leading-relaxed text-[#bdc9c2]">
+              {copy.tools.map((item) => (
+                <li key={item} className="border-l border-[#3e4944] pl-4">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="border border-[#3e4944] bg-[#181d1a] p-6 sm:p-8">
+            <div className="mb-4 flex items-center gap-3">
+              <ShieldCheck className="h-5 w-5 text-[#e040fb]" />
+              <h2 className="text-xl font-semibold text-foreground">{copy.safetyTitle}</h2>
+            </div>
+            <p className="mb-5 text-sm leading-relaxed text-[#bdc9c2]">{copy.safetyBody}</p>
+            <h3 className="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-[#a0fdda]">
+              {copy.limitationsTitle}
+            </h3>
+            <ul className="space-y-3 text-sm leading-relaxed text-[#bdc9c2]">
+              {copy.limitations.map((item) => (
+                <li key={item} className="border-l border-[#3e4944] pl-4">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section className="border border-[#3e4944] bg-[#181d1a] p-6 sm:p-8">
+          <div className="mb-4 flex items-center gap-3">
+            <Wrench className="h-5 w-5 text-[#7dd3fc]" />
+            <h2 className="text-xl font-semibold text-foreground">{copy.snippetsTitle}</h2>
+          </div>
+          <p className="mb-6 max-w-3xl text-sm leading-relaxed text-[#bdc9c2]">{copy.snippetsBody}</p>
+          <McpSnippetPreview
+            targets={EXAMPLE_TARGETS.map(({ key, targetId }) => ({
+              id: targetId,
+              label: copy[key as keyof typeof copy] as string,
+            }))}
+            footnote={copy.snippetsFootnote}
+          />
+        </section>
+
+        <section className="border border-[#3e4944] bg-[#181d1a] p-6 sm:p-8">
+          <p className="mb-5 max-w-3xl text-sm leading-relaxed text-[#bdc9c2]">{copy.nextStep}</p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href={`${localizePath(locale, "/docs")}?tab=cli`}
+              className="inline-flex min-h-11 items-center gap-2 border border-[#3e4944] bg-[#101412] px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-[#bdc9c2] transition-colors hover:border-[#a0fdda]/50 hover:text-[#f4fbf7]"
+            >
+              {copy.openCli}
+            </Link>
+            <Link
+              href={`${localizePath(locale, "/")}#catalog`}
+              className="inline-flex min-h-11 items-center gap-2 border border-accent bg-accent/10 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              {copy.openCatalog}
+            </Link>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/docs/McpSnippetPreview.tsx
+++ b/apps/web/src/components/docs/McpSnippetPreview.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { getLocalVibeBasketMcpSnippet } from "@vibebasket/core/local-mcp-snippets";
+import { useMemo, useState } from "react";
+
+type ExampleTargetId = "cursor" | "continue" | "codex" | "claude-code" | "zed" | "goose";
+
+type ExampleTarget = {
+  id: ExampleTargetId;
+  label: string;
+};
+
+type McpSnippetPreviewProps = {
+  targets: ExampleTarget[];
+  footnote: string;
+};
+
+export function McpSnippetPreview({ targets, footnote }: McpSnippetPreviewProps) {
+  const [activeTargetId, setActiveTargetId] = useState<ExampleTargetId>(targets[0]?.id ?? "cursor");
+
+  const activeTarget = targets.find((target) => target.id === activeTargetId) ?? targets[0];
+  const snippet = useMemo(
+    () => getLocalVibeBasketMcpSnippet(activeTarget?.id ?? "cursor"),
+    [activeTarget?.id],
+  );
+
+  return (
+    <div>
+      <div className="-mx-1 mb-4 flex overflow-x-auto px-1 pb-2">
+        <div className="inline-flex min-w-max gap-2">
+          {targets.map((target) => {
+            const isActive = target.id === activeTargetId;
+            return (
+              <button
+                key={target.id}
+                type="button"
+                onClick={() => setActiveTargetId(target.id)}
+                className={
+                  isActive
+                    ? "inline-flex min-h-10 items-center border border-[#a0fdda]/60 bg-[#132019] px-3 py-2 font-mono text-[11px] uppercase tracking-[0.16em] text-[#f4fbf7]"
+                    : "inline-flex min-h-10 items-center border border-[#3e4944] bg-[#101412] px-3 py-2 font-mono text-[11px] uppercase tracking-[0.16em] text-[#8da79a] transition-colors hover:border-[#a0fdda]/40 hover:text-[#dff7ea]"
+                }
+                aria-pressed={isActive}
+              >
+                {target.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <article className="border border-[#3e4944] bg-[#101412]">
+        <div className="border-b border-[#3e4944] px-4 py-3">
+          <div className="font-mono text-[11px] uppercase tracking-[0.18em] text-[#a0fdda]">
+            {activeTarget?.label}
+          </div>
+          <div className="mt-1 text-xs text-[#8da79a]">{snippet.rootField}</div>
+        </div>
+        <pre className="overflow-x-auto px-4 py-4 font-mono text-[11px] leading-relaxed text-[#dff7ea]">
+          <code>{snippet.snippet}</code>
+        </pre>
+      </article>
+
+      <p className="mt-4 text-xs leading-relaxed text-[#8da79a]">{footnote}</p>
+    </div>
+  );
+}

--- a/apps/web/src/i18n/dictionaries/en.ts
+++ b/apps/web/src/i18n/dictionaries/en.ts
@@ -19,7 +19,7 @@ export const enDictionary = {
       returnHome: "Return home",
       selfHostGuide: "Self-host guide",
       startBuildingFree: "Start building free",
-      viewCatalog: "View catalog",
+      viewCatalog: "MCP Server",
     },
     auth: {
       signIn: "Sign in",
@@ -374,6 +374,11 @@ export const enDictionary = {
       description:
         "Complete reference for vibebasket apply, list, search, doctor, init, and rollback commands. Flags, scopes, dry-run, verification, and environment variables.",
     },
+    metadataMcp: {
+      title: "Local MCP — VibeBasket Docs",
+      description:
+        "How the local VibeBasket MCP server works: stdio transport, target guidance, catalog search, install planning, apply, rollback, and current phase-1 limits.",
+    },
     metadataAdapters: {
       title: "IDE Adapters — 24 Targets — VibeBasket Docs",
       description:
@@ -406,6 +411,12 @@ export const enDictionary = {
         description:
           "Complete reference for the vibebasket apply command: bundle URLs, the --force flag, --scope overrides, --dry-run preview mode, and verification controls.",
         linkText: "View CLI reference",
+      },
+      mcp: {
+        title: "Local MCP",
+        description:
+          "Connect VibeBasket as a local stdio MCP server inside AI IDEs and use target guidance, catalog search, install planning, and apply tools without leaving the conversation.",
+        linkText: "Open MCP guide",
       },
       adapters: {
         title: "IDE Adapters",
@@ -442,6 +453,7 @@ export const enDictionary = {
         hub: "Docs",
         gettingStarted: "Getting Started",
         cli: "CLI",
+        mcp: "MCP",
         adapters: "Adapters",
         delimiters: "Delimiters",
         security: "Security",

--- a/apps/web/src/i18n/dictionaries/es.ts
+++ b/apps/web/src/i18n/dictionaries/es.ts
@@ -21,7 +21,7 @@ export const esDictionary: AppDictionary = {
       returnHome: "Volver al inicio",
       selfHostGuide: "Guía de autoalojamiento",
       startBuildingFree: "Empieza gratis",
-      viewCatalog: "Ver catálogo",
+      viewCatalog: "MCP Server",
     },
     auth: {
       signIn: "Iniciar sesión",
@@ -221,6 +221,11 @@ export const esDictionary: AppDictionary = {
       description:
         "Referencia completa de vibebasket apply, list, search, doctor, init y rollback. Flags, scopes, dry-run, verificación y variables de entorno.",
     },
+    metadataMcp: {
+      title: "MCP local — Docs de VibeBasket",
+      description:
+        "Cómo funciona el servidor MCP local de VibeBasket: transporte stdio, guía por objetivo, búsqueda de catálogo, planificación de instalación, apply, rollback y límites actuales de fase 1.",
+    },
     metadataAdapters: {
       title: "Adaptadores IDE — 24 objetivos — Docs de VibeBasket",
       description:
@@ -253,6 +258,12 @@ export const esDictionary: AppDictionary = {
         description:
           "Referencia completa del comando vibebasket apply: URLs de bundle, flag --force, overrides --scope, modo --dry-run y controles de verificación.",
         linkText: "Ver referencia CLI",
+      },
+      mcp: {
+        title: "MCP local",
+        description:
+          "Conecta VibeBasket como servidor MCP local por stdio dentro de AI IDEs y usa guía por objetivo, búsqueda de catálogo, planificación de instalación y herramientas de apply sin salir de la conversación.",
+        linkText: "Abrir guía MCP",
       },
       adapters: {
         title: "Adaptadores IDE",
@@ -289,6 +300,7 @@ export const esDictionary: AppDictionary = {
         hub: "Docs",
         gettingStarted: "Primeros pasos",
         cli: "CLI",
+        mcp: "MCP",
         adapters: "Adaptadores",
         delimiters: "Delimitadores",
         security: "Seguridad",

--- a/apps/web/src/i18n/dictionaries/hi.ts
+++ b/apps/web/src/i18n/dictionaries/hi.ts
@@ -21,7 +21,7 @@ export const hiDictionary: AppDictionary = {
       returnHome: "होम पर लौटें",
       selfHostGuide: "स्व-होस्ट गाइड",
       startBuildingFree: "मुफ़्त में बनाना शुरू करें",
-      viewCatalog: "कैटलॉग देखें",
+      viewCatalog: "MCP Server",
     },
     auth: {
       signIn: "साइन इन",
@@ -375,6 +375,11 @@ export const hiDictionary: AppDictionary = {
       description:
         "vibebasket apply, list, search, doctor, init और rollback commands के लिए पूरा संदर्भ। Flags, scopes, dry-run, verification और environment variables शामिल हैं।",
     },
+    metadataMcp: {
+      title: "लोकल MCP — VibeBasket Docs",
+      description:
+        "लोकल VibeBasket MCP server कैसे काम करता है: stdio transport, target guidance, catalog search, install planning, apply, rollback और current phase-1 limits.",
+    },
     metadataAdapters: {
       title: "IDE अडैप्टर्स — 24 लक्ष्य — VibeBasket दस्तावेज़",
       description:
@@ -407,6 +412,12 @@ export const hiDictionary: AppDictionary = {
         description:
           "vibebasket apply command के लिए पूरा संदर्भ: bundle URLs, --force flag, --scope overrides, --dry-run preview mode और verification controls।",
         linkText: "CLI संदर्भ देखें",
+      },
+      mcp: {
+        title: "लोकल MCP",
+        description:
+          "AI IDEs के भीतर VibeBasket को local stdio MCP server की तरह connect करें और target guidance, catalog search, install planning और apply tools को conversation छोड़े बिना इस्तेमाल करें.",
+        linkText: "MCP guide खोलें",
       },
       adapters: {
         title: "IDE अडैप्टर्स",
@@ -443,6 +454,7 @@ export const hiDictionary: AppDictionary = {
         hub: "दस्तावेज़",
         gettingStarted: "शुरुआत",
         cli: "CLI",
+        mcp: "MCP",
         adapters: "अडैप्टर्स",
         delimiters: "डिलिमिटर्स",
         security: "सुरक्षा",

--- a/apps/web/src/i18n/dictionaries/ru.ts
+++ b/apps/web/src/i18n/dictionaries/ru.ts
@@ -23,7 +23,7 @@ export const ruDictionary: AppDictionary = {
       returnHome: "Вернуться на главную",
       selfHostGuide: "Гайд по self-hosting",
       startBuildingFree: "Начать бесплатно",
-      viewCatalog: "Открыть каталог",
+      viewCatalog: "MCP Server",
     },
     auth: {
       ...enDictionary.shared.auth,
@@ -386,6 +386,11 @@ export const ruDictionary: AppDictionary = {
       description:
         "Полный справочник по командам vibebasket apply, list, search, doctor, init и rollback. Флаги, scope, dry-run, verification и переменные окружения.",
     },
+    metadataMcp: {
+      title: "Локальный MCP — Документация VibeBasket",
+      description:
+        "Как работает локальный MCP-сервер VibeBasket: stdio transport, target guidance, поиск по каталогу, планирование установки, apply, rollback и текущие ограничения phase 1.",
+    },
     metadataAdapters: {
       title: "IDE Adapters — 24 Targets — VibeBasket Docs",
       description:
@@ -418,6 +423,12 @@ export const ruDictionary: AppDictionary = {
         description:
           "Полный справочник по команде vibebasket apply: bundle URL, флаг --force, overrides через --scope, режим preview через --dry-run и verification controls.",
         linkText: "Открыть CLI reference",
+      },
+      mcp: {
+        title: "Локальный MCP",
+        description:
+          "Подключите VibeBasket как локальный stdio MCP-сервер внутри AI IDE и используйте guidance по целям, поиск по каталогу, планирование установки и apply-инструменты, не выходя из диалога.",
+        linkText: "Открыть MCP guide",
       },
       adapters: {
         title: "IDE-адаптеры",
@@ -454,6 +465,7 @@ export const ruDictionary: AppDictionary = {
         hub: "Docs",
         gettingStarted: "Быстрый старт",
         cli: "CLI",
+        mcp: "MCP",
         adapters: "Адаптеры",
         delimiters: "Delimiters",
         security: "Security",

--- a/apps/web/src/i18n/dictionaries/tr.ts
+++ b/apps/web/src/i18n/dictionaries/tr.ts
@@ -21,7 +21,7 @@ export const trDictionary: AppDictionary = {
       returnHome: "Ana sayfaya dön",
       selfHostGuide: "Kendi sunucunda çalıştırma rehberi",
       startBuildingFree: "Ücretsiz oluşturmaya başla",
-      viewCatalog: "Kataloğu görüntüle",
+      viewCatalog: "MCP Server",
     },
     auth: {
       signIn: "Giriş yap",
@@ -378,6 +378,11 @@ export const trDictionary: AppDictionary = {
       description:
         "vibebasket apply, list, search, doctor, init ve rollback komutları için tam referans. Flag’ler, scope’lar, dry-run, doğrulama ve environment değişkenleri.",
     },
+    metadataMcp: {
+      title: "Yerel MCP — VibeBasket Dokümanları",
+      description:
+        "Yerel VibeBasket MCP sunucusunun nasıl çalıştığı: stdio taşıması, hedef rehberliği, katalog arama, kurulum planlama, apply, rollback ve mevcut phase-1 sınırları.",
+    },
     metadataAdapters: {
       title: "IDE Adaptörleri — 24 Hedef — VibeBasket Dokümanları",
       description:
@@ -410,6 +415,12 @@ export const trDictionary: AppDictionary = {
         description:
           "vibebasket apply komutu için tam referans: bundle URL’leri, --force, --scope, --dry-run ve doğrulama kontrolleri.",
         linkText: "CLI referansını aç",
+      },
+      mcp: {
+        title: "Yerel MCP",
+        description:
+          "VibeBasket’i AI IDE’ler içinde yerel stdio MCP sunucusu olarak bağla; hedef rehberliği, katalog arama, kurulum planlama ve apply araçlarını konuşmadan çıkmadan kullan.",
+        linkText: "MCP rehberini aç",
       },
       adapters: {
         title: "IDE Adaptörleri",
@@ -446,6 +457,7 @@ export const trDictionary: AppDictionary = {
         hub: "Dokümanlar",
         gettingStarted: "Başlangıç",
         cli: "CLI",
+        mcp: "MCP",
         adapters: "Adaptörler",
         delimiters: "Delimiter’lar",
         security: "Güvenlik",

--- a/apps/web/src/i18n/dictionaries/zh.ts
+++ b/apps/web/src/i18n/dictionaries/zh.ts
@@ -21,7 +21,7 @@ export const zhDictionary: AppDictionary = {
       returnHome: "返回首页",
       selfHostGuide: "自托管指南",
       startBuildingFree: "免费开始构建",
-      viewCatalog: "查看目录",
+      viewCatalog: "MCP Server",
     },
     auth: {
       signIn: "登录",
@@ -366,6 +366,11 @@ export const zhDictionary: AppDictionary = {
       description:
         "vibebasket apply、list、search、doctor、init 和 rollback 的完整参考。包含参数、作用域、dry-run、校验和环境变量。",
     },
+    metadataMcp: {
+      title: "本地 MCP — VibeBasket 文档",
+      description:
+        "本地 VibeBasket MCP 服务如何工作：stdio 传输、目标指导、目录搜索、安装规划、apply、rollback 以及当前 phase-1 边界。",
+    },
     metadataAdapters: {
       title: "IDE 适配器 — 24 个目标 — VibeBasket 文档",
       description:
@@ -398,6 +403,12 @@ export const zhDictionary: AppDictionary = {
         description:
           "vibebasket apply 命令的完整参考：bundle URL、--force、--scope 覆盖、--dry-run 预览模式和校验控制。",
         linkText: "查看 CLI 参考",
+      },
+      mcp: {
+        title: "本地 MCP",
+        description:
+          "在 AI IDE 中将 VibeBasket 作为本地 stdio MCP 服务接入，并在不离开对话的情况下使用目标指导、目录搜索、安装规划与 apply 工具。",
+        linkText: "打开 MCP 指南",
       },
       adapters: {
         title: "IDE 适配器",
@@ -434,6 +445,7 @@ export const zhDictionary: AppDictionary = {
         hub: "文档",
         gettingStarted: "快速开始",
         cli: "CLI",
+        mcp: "MCP",
         adapters: "适配器",
         delimiters: "分隔符",
         security: "安全",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ We use `pnpm workspaces` to manage the project.
 - `packages/adapters`: Contains 24 IDE adapters (Cursor, Windsurf, VS Code/Cline, Antigravity, Claude Code, DeepSeek-TUI, Zed, Codex CLI, Gemini CLI, Junie, Kiro, Cline CLI, Continue, Roo Code, Hermes, OpenClaw, GitHub Copilot, Void Editor, Aider, Cortex Code, Goose, IBM Bob, CodeBuddy, and OpenCode) that handle config generation, backups, and idempotency. 16 adapters extend BaseAdapter for shared readConfig/applyMcps/writeConfig/diff logic, while `CodexAdapter` and other custom adapters handle target-native TOML/YAML or instruction surfaces.
 - `packages/registry`: Automated catalog synchronization logic from trusted external sources and local curated data, including the semver deduplication engine for official upstream MCP servers.
 - `apps/web`: Next.js 16.2.9 App Router providing the catalog and selection UI, `/docs` documentation hub, `/stacks` saved-stack management, and the `/admin` stats dashboard.
-- `apps/cli`: Node.js CLI tool running the execution environment.
+- `apps/cli`: Node.js CLI tool running the execution environment, plus the local stdio MCP server surface exposed through `vibebasket mcp serve`.
 
 ## Data Flow
 1. Web App constructs a bundle (JSON).
@@ -29,6 +29,8 @@ We use `pnpm workspaces` to manage the project.
 3. CLI fetches the bundle, resolves secrets locally (never sent to the cloud).
 4. Adapters modify IDE configuration files incrementally and idempotently.
 5. The CLI re-reads the target configuration and verifies deterministic artifacts after writes when verification is enabled (default).
+
+For local MCP sessions, the same CLI service layer is reused instead of shelling out to child `vibebasket` processes. That keeps target guidance, native MCP snippet rendering, install planning, apply behavior, backup lookup, and rollback aligned with the normal CLI path.
 
 For filesystem-backed Skills, Rules, and Continue prompts, VibeBasket now tracks its own managed files with a local sidecar registry. Existing foreign files at the same path are skipped instead of overwritten, while previously managed VibeBasket files remain safely updatable and backed up before changes.
 
@@ -117,6 +119,27 @@ Response shape:
 }
 ```
 
+`GET /api/catalog/item/[id]`
+
+Returns a single catalog item by stable catalog id. The local MCP server uses this endpoint for precise item lookups and stack snapshot hydration.
+
+Response shape:
+
+```json
+{
+  "id": "skill-example",
+  "type": "skill",
+  "displayName": "Example Skill",
+  "description": "Optional description",
+  "sourceName": "skills.sh",
+  "sourceUrl": "https://www.skills.sh/...",
+  "verified": false,
+  "official": false,
+  "lastSyncedAt": "2026-07-23T00:00:00.000Z",
+  "data": {}
+}
+```
+
 `GET /api/catalog/status`
 
 Returns current catalog counts, freshness derived from the newest catalog row, and the latest recorded sync run summary from `catalog_sync_runs`.
@@ -154,6 +177,7 @@ The homepage (`/`) is `force-dynamic` and server-renders:
 - request-driven stale refresh is intentionally lightweight; deterministic production freshness still comes from an external scheduler invoking `pnpm catalog:sync`
 - expired bundle/session cleanup is also request-triggered today; quiet self-hosted instances should not assume idle-time cleanup without an external maintenance trigger
 - item-level freshness now lives on `catalog_items` itself, so future UI trust/freshness badges do not need a second storage model
+- local MCP catalog reads intentionally go through the web API rather than bypassing into the database, so hosted and self-hosted sessions share one catalog authority, one trust model, and one refresh guardrail surface
 - the web package now participates in workspace `test` and `typecheck` runs, so catalog discovery logic is covered by the same verification path as the packages
 - catalog selection state in the web app is driven directly from the basket store state
 - basket persistence falls back to an in-memory adapter outside the browser so tests and SSR contexts do not emit noisy missing-`localStorage` warnings

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -2,6 +2,8 @@
 
 VibeBasket is a bundle-and-apply platform for AI development environments. It gives users a single web catalog where they can browse trusted MCP servers, skills, and rules, collect them into a basket, and generate a shareable bundle URL plus a single CLI command to apply the setup locally.
 
+The same CLI now also exposes a local stdio MCP server so supported AI IDEs can search the catalog, inspect target guidance, plan installs, and apply bundles without leaving the IDE conversation.
+
 ## Table of Contents
 
 - [Product Goal](#product-goal)
@@ -54,7 +56,8 @@ Trust labels are intentionally narrower than source provenance:
 
 Recent work significantly changed the catalog behavior, deployment, and security baseline:
 
-- **Phase 1 localization:** public routes, metadata, docs shell, login surface, and key admin shell labels now support English, Turkish, and Spanish under `/en`, `/tr`, and `/es`.
+- **Localization baseline:** public routes, metadata, docs shell, login surface, and key admin shell labels now support English, Turkish, Spanish, Chinese, Hindi, and Russian under locale-prefixed routes.
+- **Local MCP phase 1:** `npx vibebasket mcp serve` now reuses the real CLI services for catalog search, item lookup, target guidance, target-native MCP snippet rendering, install planning, apply, rollback, backup listing, and local stack save/load.
 - **Localized SEO:** canonical and `hreflang` output now comes from shared locale helpers so translated routes stay indexable without drifting from the main URL model.
 - **Dockerization & Production Config:** Multi-stage production `Dockerfile` based on Node.js 22 Alpine utilizing lean Next.js standalone build outputs, root privilege isolation, and SQLite volume persistence. Added `docker-compose.yml` with automated container health probes and `.dockerignore` shielding.
 - **Kubernetes Helm Chart:** Chart at `charts/vibebasket/` with Recreate strategy, securityContext uid 1001, existingSecret support, PVC-backed SQLite persistence, and `/api/health`-based liveness/readiness probes.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./manifest": "./src/manifest.ts",
+    "./local-mcp-snippets": "./src/local-mcp-snippets.ts",
     "./db": "./src/db/index.ts"
   },
   "scripts": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./manifest";
+export * from "./local-mcp-snippets";
 export * from "./db";

--- a/packages/core/src/local-mcp-snippets.test.ts
+++ b/packages/core/src/local-mcp-snippets.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getLocalVibeBasketMcpSnippet } from "./local-mcp-snippets";
+
+describe("local MCP snippets", () => {
+  it("renders JSON shape for cursor", () => {
+    const snippet = getLocalVibeBasketMcpSnippet("cursor");
+
+    expect(snippet.format).toBe("json");
+    expect(snippet.rootField).toBe("mcpServers");
+    expect(snippet.snippet).toContain('"mcpServers"');
+    expect(snippet.snippet).toContain('"vibebasket"');
+  });
+
+  it("renders YAML shape for continue", () => {
+    const snippet = getLocalVibeBasketMcpSnippet("continue");
+
+    expect(snippet.format).toBe("yaml");
+    expect(snippet.rootField).toBe("mcpServers");
+    expect(snippet.snippet).toContain("mcpServers:");
+    expect(snippet.snippet).toContain("- name: vibebasket");
+  });
+
+  it("renders TOML shape for codex", () => {
+    const snippet = getLocalVibeBasketMcpSnippet("codex");
+
+    expect(snippet.format).toBe("toml");
+    expect(snippet.rootField).toBe("mcp_servers.vibebasket");
+    expect(snippet.snippet).toContain("[mcp_servers.vibebasket]");
+    expect(snippet.snippet).toContain('command = "npx"');
+  });
+});

--- a/packages/core/src/local-mcp-snippets.ts
+++ b/packages/core/src/local-mcp-snippets.ts
@@ -1,0 +1,178 @@
+import type { IdeId } from "./manifest";
+
+export type LocalMcpSnippetFormat = "json" | "yaml" | "toml";
+
+export const VIBEBASKET_MCP_SERVER_ID = "vibebasket" as const;
+export const VIBEBASKET_LOCAL_MCP_COMMAND = "npx" as const;
+export const VIBEBASKET_LOCAL_MCP_ARGS = ["-y", "vibebasket", "mcp", "serve"] as const;
+export const VIBEBASKET_LOCAL_MCP_ENV = {
+  VIBEBASKET_API_URL: "https://vibebasket.dev",
+  VIBEBASKET_MCP_WRITE_POLICY: "confirm",
+} as const;
+
+export type LocalMcpSnippet = {
+  format: LocalMcpSnippetFormat;
+  rootField: string;
+  snippet: string;
+  mergeStrategyNote: string;
+};
+
+export function getBaseVibeBasketServerDefinition() {
+  return {
+    serverId: VIBEBASKET_MCP_SERVER_ID,
+    transport: "stdio" as const,
+    command: VIBEBASKET_LOCAL_MCP_COMMAND,
+    args: [...VIBEBASKET_LOCAL_MCP_ARGS],
+    optionalEnv: { ...VIBEBASKET_LOCAL_MCP_ENV },
+  };
+}
+
+function renderJsonSnippet(rootKey: string) {
+  return JSON.stringify(
+    {
+      [rootKey]: {
+        [VIBEBASKET_MCP_SERVER_ID]: {
+          command: VIBEBASKET_LOCAL_MCP_COMMAND,
+          args: [...VIBEBASKET_LOCAL_MCP_ARGS],
+          env: { ...VIBEBASKET_LOCAL_MCP_ENV },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+function renderContinueYamlSnippet() {
+  return [
+    "mcpServers:",
+    `  - name: ${VIBEBASKET_MCP_SERVER_ID}`,
+    `    command: ${VIBEBASKET_LOCAL_MCP_COMMAND}`,
+    "    args:",
+    ...VIBEBASKET_LOCAL_MCP_ARGS.map((arg) => `      - ${JSON.stringify(arg)}`),
+    "    env:",
+    ...Object.entries(VIBEBASKET_LOCAL_MCP_ENV).map(
+      ([key, value]) => `      ${key}: ${JSON.stringify(value)}`,
+    ),
+  ].join("\n");
+}
+
+function renderCodexTomlSnippet() {
+  return [
+    `[mcp_servers.${VIBEBASKET_MCP_SERVER_ID}]`,
+    `command = ${JSON.stringify(VIBEBASKET_LOCAL_MCP_COMMAND)}`,
+    `args = [${VIBEBASKET_LOCAL_MCP_ARGS.map((arg) => JSON.stringify(arg)).join(", ")}]`,
+    `env = { ${Object.entries(VIBEBASKET_LOCAL_MCP_ENV)
+      .map(([key, value]) => `${key} = ${JSON.stringify(value)}`)
+      .join(", ")} }`,
+  ].join("\n");
+}
+
+function renderGooseYamlSnippet() {
+  return [
+    "extensions:",
+    `  ${VIBEBASKET_MCP_SERVER_ID}:`,
+    `    name: ${VIBEBASKET_MCP_SERVER_ID}`,
+    "    enabled: true",
+    "    type: stdio",
+    "    timeout: 300",
+    `    cmd: ${VIBEBASKET_LOCAL_MCP_COMMAND}`,
+    `    args: [${VIBEBASKET_LOCAL_MCP_ARGS.map((arg) => JSON.stringify(arg)).join(", ")}]`,
+    "    envs:",
+    ...Object.entries(VIBEBASKET_LOCAL_MCP_ENV).map(
+      ([key, value]) => `      ${key}: ${JSON.stringify(value)}`,
+    ),
+  ].join("\n");
+}
+
+function renderHermesYamlSnippet() {
+  return [
+    "mcp_servers:",
+    `  ${VIBEBASKET_MCP_SERVER_ID}:`,
+    `    command: ${JSON.stringify(VIBEBASKET_LOCAL_MCP_COMMAND)}`,
+    "    args:",
+    ...VIBEBASKET_LOCAL_MCP_ARGS.map((arg) => `      - ${JSON.stringify(arg)}`),
+    "    env:",
+    ...Object.entries(VIBEBASKET_LOCAL_MCP_ENV).map(
+      ([key, value]) => `      ${key}: ${JSON.stringify(value)}`,
+    ),
+  ].join("\n");
+}
+
+function renderOpenCodeJsonSnippet() {
+  return JSON.stringify(
+    {
+      mcp: {
+        [VIBEBASKET_MCP_SERVER_ID]: {
+          type: "local",
+          enabled: true,
+          command: [VIBEBASKET_LOCAL_MCP_COMMAND, ...VIBEBASKET_LOCAL_MCP_ARGS],
+          environment: { ...VIBEBASKET_LOCAL_MCP_ENV },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+export function getLocalVibeBasketMcpSnippet(targetId: IdeId): LocalMcpSnippet {
+  switch (targetId) {
+    case "codex":
+      return {
+        format: "toml",
+        rootField: `mcp_servers.${VIBEBASKET_MCP_SERVER_ID}`,
+        snippet: renderCodexTomlSnippet(),
+        mergeStrategyNote:
+          "Merge this TOML block into the existing config.toml. Do not replace unrelated sections.",
+      };
+    case "continue":
+      return {
+        format: "yaml",
+        rootField: "mcpServers",
+        snippet: renderContinueYamlSnippet(),
+        mergeStrategyNote:
+          "Merge this list item into the existing top-level mcpServers list. If the file is brand new, keep Continue's required name, version, and schema keys too.",
+      };
+    case "zed":
+      return {
+        format: "json",
+        rootField: "context_servers",
+        snippet: renderJsonSnippet("context_servers"),
+        mergeStrategyNote:
+          "Merge this fragment into the existing context_servers object and preserve other Zed settings.",
+      };
+    case "goose":
+      return {
+        format: "yaml",
+        rootField: "extensions",
+        snippet: renderGooseYamlSnippet(),
+        mergeStrategyNote:
+          "Merge this server into the existing extensions block instead of overwriting other Goose extensions.",
+      };
+    case "hermes":
+      return {
+        format: "yaml",
+        rootField: "mcp_servers",
+        snippet: renderHermesYamlSnippet(),
+        mergeStrategyNote:
+          "Merge this server into the existing mcp_servers block and preserve unrelated Hermes settings.",
+      };
+    case "opencode":
+      return {
+        format: "json",
+        rootField: "mcp",
+        snippet: renderOpenCodeJsonSnippet(),
+        mergeStrategyNote:
+          "Merge this fragment into the top-level mcp object. Keep existing OpenCode config keys untouched.",
+      };
+    default:
+      return {
+        format: "json",
+        rootField: "mcpServers",
+        snippet: renderJsonSnippet("mcpServers"),
+        mergeStrategyNote:
+          "Merge this fragment into the existing mcpServers object and preserve unrelated config entries.",
+      };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@inquirer/prompts':
         specifier: ^8.5.2
         version: 8.5.2(@types/node@25.6.2)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -36,6 +39,9 @@ importers:
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^25.6.2
@@ -617,11 +623,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -6599,7 +6605,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-own-enumerable-keys@1.0.0: {}


### PR DESCRIPTION
## Summary
- add the phase-1 local stdio MCP surface to the CLI and reuse shared services for catalog search, item lookup, target guidance, install plan/apply, backup list/rollback, and local stack save/load
- add a dedicated catalog item API plus shared target-native MCP snippet rendering used by both CLI guidance and the docs hub
- add selectable docs-side MCP snippet previews, MCP hardening around local stack loading, and focused regression coverage for refresh cooldown/dedupe and snippet rendering

## Verification
- pnpm --filter @vibebasket/core test
- pnpm --filter vibebasket test
- pnpm --filter web test -- --runInBand
- pnpm --filter web build
- pnpm exec playwright test e2e/ui.spec.ts -g "docs MCP snippet preview switches targets without overflow"