### PR TITLE
chore: fix CI formatting regressions after local MCP rollout

### DIFF
--- a/apps/cli/src/apply.ts
+++ b/apps/cli/src/apply.ts
@@ -12,9 +12,15 @@ export async function applyBundle(
   const projectRoot = scope === "project" ? process.cwd() : undefined;
 
   console.log(chalk.bold("\n📦 Bundle Summary:"));
-  console.log(`- MCP Servers: ${bundle.mcps.length + bundle.workflowPacks.flatMap((entry) => entry.mcps).length}`);
-  console.log(`- Skills: ${bundle.skills.length + bundle.workflowPacks.flatMap((entry) => entry.skills).length}`);
-  console.log(`- Rules: ${bundle.rules.length + bundle.workflowPacks.flatMap((entry) => entry.rules).length}`);
+  console.log(
+    `- MCP Servers: ${bundle.mcps.length + bundle.workflowPacks.flatMap((entry) => entry.mcps).length}`,
+  );
+  console.log(
+    `- Skills: ${bundle.skills.length + bundle.workflowPacks.flatMap((entry) => entry.skills).length}`,
+  );
+  console.log(
+    `- Rules: ${bundle.rules.length + bundle.workflowPacks.flatMap((entry) => entry.rules).length}`,
+  );
   console.log(`- Workflow Files: ${bundle.workflowPacks.flatMap((entry) => entry.files).length}`);
   console.log(`- Targets: ${bundle.targets.join(", ")}`);
   console.log(`- Scope: ${scope}\n`);

--- a/apps/cli/src/mcp/policy.ts
+++ b/apps/cli/src/mcp/policy.ts
@@ -1,6 +1,6 @@
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type { ServerNotification, ServerRequest } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type { WritePolicyMode } from "./types.js";
 
 export type ToolRiskLevel = "low" | "medium" | "high";
@@ -54,7 +54,9 @@ export async function enforceToolPolicy(
       },
     });
     const parsed = ConfirmationResponseSchema.safeParse(
-      result && typeof result === "object" && "content" in result ? (result as { content?: unknown }).content : result,
+      result && typeof result === "object" && "content" in result
+        ? (result as { content?: unknown }).content
+        : result,
     );
     if (parsed.success && parsed.data.approved) {
       return { allowed: true };

--- a/apps/cli/src/mcp/server.ts
+++ b/apps/cli/src/mcp/server.ts
@@ -3,10 +3,10 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { IdeIdSchema, ScopeSchema } from "../../../../packages/core/src/manifest.js";
+import { restoreBackupByPath } from "../services/rollback-service.js";
 import { enforceToolPolicy } from "./policy.js";
 import { VibebasketMcpServices } from "./services.js";
-import { SelectionInputSchema, type McpToolEnvelope } from "./types.js";
-import { restoreBackupByPath } from "../services/rollback-service.js";
+import { type McpToolEnvelope, SelectionInputSchema } from "./types.js";
 
 function toolText<T extends Record<string, unknown>>(payload: McpToolEnvelope<T>): CallToolResult {
   return {
@@ -64,7 +64,10 @@ const InstallApplyInputSchema = z
   });
 
 const LocalStackLoadSchema = z.object({
-  stackId: z.string().trim().regex(/^[a-z0-9-]+$/),
+  stackId: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9-]+$/),
 });
 
 const SaveLocalStackSchema = SelectionInputSchema.extend({
@@ -195,7 +198,8 @@ export async function createVibeBasketMcpServer() {
   server.registerTool(
     "catalog.refresh",
     {
-      description: "Refresh the MCP session's cached view of the VibeBasket catalog with cooldown protection.",
+      description:
+        "Refresh the MCP session's cached view of the VibeBasket catalog with cooldown protection.",
       inputSchema: z.object({}),
     },
     async (_args, extra) => {
@@ -244,13 +248,16 @@ export async function createVibeBasketMcpServer() {
   server.registerTool(
     "stack.save_local",
     {
-      description: "Save the current selection as a local reusable VibeBasket stack on this machine.",
+      description:
+        "Save the current selection as a local reusable VibeBasket stack on this machine.",
       inputSchema: SaveLocalStackSchema,
     },
     async (args, extra) => {
       const policy = await enforceToolPolicy("medium", extra, "save a local VibeBasket stack");
       if (!policy.allowed) {
-        return toolText(failure("policy_blocked", policy.reason ?? "Save blocked.", {}, policy.reason));
+        return toolText(
+          failure("policy_blocked", policy.reason ?? "Save blocked.", {}, policy.reason),
+        );
       }
 
       const stack = await services.saveLocalStack(args);
@@ -267,7 +274,8 @@ export async function createVibeBasketMcpServer() {
   server.registerTool(
     "stack.save_cloud",
     {
-      description: "Attempt to save a stack to the authenticated VibeBasket profile. Phase 1 reports availability and guidance only.",
+      description:
+        "Attempt to save a stack to the authenticated VibeBasket profile. Phase 1 reports availability and guidance only.",
       inputSchema: SaveLocalStackSchema,
     },
     async () =>
@@ -290,9 +298,7 @@ export async function createVibeBasketMcpServer() {
     async ({ stackId }) => {
       const stack = await services.loadLocalStack(stackId);
       if (!stack) {
-        return toolText(
-          failure("not_found", `Local stack ${stackId} was not found.`, { stackId }),
-        );
+        return toolText(failure("not_found", `Local stack ${stackId} was not found.`, { stackId }));
       }
       return toolText(
         success(
@@ -340,9 +346,15 @@ export async function createVibeBasketMcpServer() {
       inputSchema: InstallApplyInputSchema,
     },
     async (args, extra) => {
-      const policy = await enforceToolPolicy("high", extra, "apply configuration changes to local AI IDEs");
+      const policy = await enforceToolPolicy(
+        "high",
+        extra,
+        "apply configuration changes to local AI IDEs",
+      );
       if (!policy.allowed) {
-        return toolText(failure("policy_blocked", policy.reason ?? "Apply blocked.", {}, policy.reason));
+        return toolText(
+          failure("policy_blocked", policy.reason ?? "Apply blocked.", {}, policy.reason),
+        );
       }
 
       try {
@@ -390,13 +402,18 @@ export async function createVibeBasketMcpServer() {
   server.registerTool(
     "install.rollback",
     {
-      description: "Restore a previously created VibeBasket backup by backup filename path metadata.",
+      description:
+        "Restore a previously created VibeBasket backup by backup filename path metadata.",
       inputSchema: z.object({
         backupPath: z.string().trim().min(1),
       }),
     },
     async ({ backupPath }, extra) => {
-      const policy = await enforceToolPolicy("high", extra, "restore a previous configuration backup");
+      const policy = await enforceToolPolicy(
+        "high",
+        extra,
+        "restore a previous configuration backup",
+      );
       if (!policy.allowed) {
         return toolText(
           failure("policy_blocked", policy.reason ?? "Rollback blocked.", {}, policy.reason),

--- a/apps/cli/src/mcp/services.ts
+++ b/apps/cli/src/mcp/services.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { CatalogApiClient } from "../services/catalog-api.js";
-import { createBundleFromSelection, loadBundleFromInput } from "../services/bundle-service.js";
+import type { IdeId, Scope } from "../../../../packages/core/src/manifest.js";
+import { listBackups } from "../backup.js";
+import { getApiBaseUrl } from "../services/api-base-url.js";
 import { executeBundleApply } from "../services/apply-service.js";
+import { createBundleFromSelection, loadBundleFromInput } from "../services/bundle-service.js";
+import { CatalogApiClient } from "../services/catalog-api.js";
 import {
   createLocalStackId,
   getLocalStack,
@@ -9,16 +12,13 @@ import {
   listLocalStacks,
   saveLocalStack,
 } from "../services/local-stacks.js";
-import { getApiBaseUrl } from "../services/api-base-url.js";
-import { listBackups } from "../backup.js";
-import { getWritePolicyMode } from "./policy.js";
-import type { SelectionInput } from "./types.js";
 import {
   getTargetMcpSnippet,
   getTargetSetupGuide,
   listTargetGuides,
 } from "../services/target-guidance.js";
-import type { IdeId, Scope } from "../../../../packages/core/src/manifest.js";
+import { getWritePolicyMode } from "./policy.js";
+import type { SelectionInput } from "./types.js";
 
 export class VibebasketMcpServices {
   readonly sessionId = randomUUID();
@@ -80,21 +80,28 @@ export class VibebasketMcpServices {
   }
 
   async applyInstall(input: { bundleUrl?: string; selection?: SelectionInput; force?: boolean }) {
+    if (!input.bundleUrl && !input.selection) {
+      throw new Error("applyInstall requires either bundleUrl or selection.");
+    }
+
     const bundle =
       input.bundleUrl != null
         ? await loadBundleFromInput(input.bundleUrl)
-        : (await createBundleFromSelection({
-            itemIds: input.selection!.itemIds,
-            targetIds: input.selection!.targetIds,
-            scope: input.selection!.scope,
-          })).bundle;
+        : (
+            await createBundleFromSelection({
+              itemIds: input.selection.itemIds,
+              targetIds: input.selection.targetIds,
+              scope: input.selection.scope,
+            })
+          ).bundle;
 
     return executeBundleApply(bundle, {
       scope: input.selection?.scope ?? bundle.scope,
       force: input.force ?? false,
       dryRun: false,
       verify: true,
-      projectRoot: (input.selection?.scope ?? bundle.scope) === "project" ? process.cwd() : undefined,
+      projectRoot:
+        (input.selection?.scope ?? bundle.scope) === "project" ? process.cwd() : undefined,
       interactiveSecrets: false,
     });
   }

--- a/apps/cli/src/services/apply-service.ts
+++ b/apps/cli/src/services/apply-service.ts
@@ -96,7 +96,7 @@ export async function executeBundleApply(
 ): Promise<ApplyServiceResult> {
   const logger = options.logger ?? noopLogger;
   const scope = options.scope ?? bundle.scope;
-  const projectRoot = scope === "project" ? options.projectRoot ?? process.cwd() : undefined;
+  const projectRoot = scope === "project" ? (options.projectRoot ?? process.cwd()) : undefined;
   const flattened = flattenBundleContent(bundle);
 
   const unsupportedTargets = bundle.targets.filter((targetId) => !getAdapter(targetId));
@@ -160,7 +160,9 @@ export async function executeBundleApply(
         "Workflow files were included, but file scaffolds only apply in project scope. Skipping workflow files.",
       );
     } else if (options.dryRun) {
-      logger.info(`Dry run: would apply ${flattened.files.length} workflow file(s) under ${projectRoot}.`);
+      logger.info(
+        `Dry run: would apply ${flattened.files.length} workflow file(s) under ${projectRoot}.`,
+      );
     } else {
       const workflowResult = await applyWorkflowFiles(flattened.files, projectRoot);
       workflowFilesApplied.push(...workflowResult.written);
@@ -302,11 +304,17 @@ async function applyToTarget(
   }
 
   if (options.verify) {
-    const verification = await verifyTargetInstall(targetId, adapter, options.scope, options.projectRoot, {
-      mcps: shouldApplyMcps ? mcpPlan.supported : [],
-      skills: shouldApplySkills ? flattened.skills : [],
-      rules: shouldApplyRules ? flattened.rules : [],
-    });
+    const verification = await verifyTargetInstall(
+      targetId,
+      adapter,
+      options.scope,
+      options.projectRoot,
+      {
+        mcps: shouldApplyMcps ? mcpPlan.supported : [],
+        skills: shouldApplySkills ? flattened.skills : [],
+        rules: shouldApplyRules ? flattened.rules : [],
+      },
+    );
 
     if (!verification.ok) {
       throw new Error(

--- a/apps/cli/src/services/bundle-service.ts
+++ b/apps/cli/src/services/bundle-service.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import {
-  BundleSchema,
   type Bundle,
+  BundleSchema,
   type IdeId,
   type Scope,
 } from "../../../../packages/core/src/manifest.js";

--- a/apps/cli/src/services/catalog-api.test.ts
+++ b/apps/cli/src/services/catalog-api.test.ts
@@ -25,10 +25,18 @@ describe("CatalogApiClient refresh guardrails", () => {
           calls += 1;
           resolveFetch = () =>
             resolve(
-              new Response(JSON.stringify({ items: [], pagination: undefined, source: "network", cached: false }), {
-                status: 200,
-                headers: { "content-type": "application/json" },
-              }),
+              new Response(
+                JSON.stringify({
+                  items: [],
+                  pagination: undefined,
+                  source: "network",
+                  cached: false,
+                }),
+                {
+                  status: 200,
+                  headers: { "content-type": "application/json" },
+                },
+              ),
             );
         }),
     ) as typeof fetch;
@@ -49,7 +57,10 @@ describe("CatalogApiClient refresh guardrails", () => {
     global.fetch = vi.fn(async () => new Response("{}", { status: 200 })) as typeof fetch;
 
     const client = new CatalogApiClient("https://vibebasket.dev");
-    await expect(client.refresh()).resolves.toMatchObject({ refreshed: true, cooldownMsRemaining: 0 });
+    await expect(client.refresh()).resolves.toMatchObject({
+      refreshed: true,
+      cooldownMsRemaining: 0,
+    });
     await expect(client.refresh()).resolves.toMatchObject({
       refreshed: false,
       forced: false,

--- a/apps/cli/src/services/target-guidance.ts
+++ b/apps/cli/src/services/target-guidance.ts
@@ -1,8 +1,8 @@
 import { TARGET_CAPABILITIES } from "../../../../packages/adapters/src/target-capabilities.js";
 import {
+  VIBEBASKET_MCP_SERVER_ID,
   getBaseVibeBasketServerDefinition,
   getLocalVibeBasketMcpSnippet,
-  VIBEBASKET_MCP_SERVER_ID,
 } from "../../../../packages/core/src/local-mcp-snippets.js";
 import type { IdeId, Scope } from "../../../../packages/core/src/manifest.js";
 
@@ -29,7 +29,8 @@ const TARGET_GUIDES: Record<IdeId, TargetGuideMetadata> = {
       project: "<project-root>/.gemini/antigravity/mcp_config.json",
     },
     mcpFieldHint: "Add an mcpServers.vibebasket entry in the JSON config.",
-    postInstallHint: "Restart Antigravity or reload the conversation for MCP changes to take effect.",
+    postInstallHint:
+      "Restart Antigravity or reload the conversation for MCP changes to take effect.",
   },
   "claude-code": {
     label: "Claude Code",
@@ -194,7 +195,8 @@ const TARGET_GUIDES: Record<IdeId, TargetGuideMetadata> = {
       project: "~/.hermes/config.yaml",
     },
     mcpFieldHint: "Add a vibebasket block under Hermes mcp_servers in YAML form.",
-    postInstallHint: "Restart Hermes or reload the terminal for configuration changes to take effect.",
+    postInstallHint:
+      "Restart Hermes or reload the terminal for configuration changes to take effect.",
   },
   openclaw: {
     label: "OpenClaw",
@@ -257,7 +259,8 @@ const TARGET_GUIDES: Record<IdeId, TargetGuideMetadata> = {
       user: "~/.config/goose/config.yaml",
     },
     mcpFieldHint: "Add a vibebasket entry inside the Goose extensions config.",
-    postInstallHint: "Restart Goose or reload the terminal for configuration changes to take effect.",
+    postInstallHint:
+      "Restart Goose or reload the terminal for configuration changes to take effect.",
   },
   "ibm-bob": {
     label: "IBM Bob",
@@ -361,10 +364,15 @@ export function getTargetSetupGuide(targetId: IdeId, scope: Scope = "user") {
       capabilities.supportsMcp && scopeSupported
         ? {
             ...getBaseVibeBasketServerDefinition(),
-            postInstallHint: metadata.postInstallHint ?? "Restart the client after updating its MCP config.",
+            postInstallHint:
+              metadata.postInstallHint ?? "Restart the client after updating its MCP config.",
           }
         : null,
-    recommendedSteps: buildRecommendedSteps(targetId, scope, capabilities.supportsMcp && scopeSupported),
+    recommendedSteps: buildRecommendedSteps(
+      targetId,
+      scope,
+      capabilities.supportsMcp && scopeSupported,
+    ),
   };
 }
 

--- a/apps/web/src/app/[locale]/docs/page.tsx
+++ b/apps/web/src/app/[locale]/docs/page.tsx
@@ -53,15 +53,15 @@ export async function generateMetadata({
         ? docs.metadataCli
         : tab === "mcp"
           ? docs.metadataMcp
-        : tab === "adapters"
-          ? docs.metadataAdapters
-          : tab === "delimiters"
-            ? docs.metadataDelimiters
-            : tab === "security"
-              ? docs.metadataSecurity
-              : tab === "self-hosting"
-                ? docs.metadataSelfHosting
-                : docs.metadataHub;
+          : tab === "adapters"
+            ? docs.metadataAdapters
+            : tab === "delimiters"
+              ? docs.metadataDelimiters
+              : tab === "security"
+                ? docs.metadataSecurity
+                : tab === "self-hosting"
+                  ? docs.metadataSelfHosting
+                  : docs.metadataHub;
 
   const localizedDocsPath = tab ? `/docs?tab=${tab}` : "/docs";
   const languageAlternates = Object.fromEntries(

--- a/apps/web/src/app/api/catalog/item/[id]/route.ts
+++ b/apps/web/src/app/api/catalog/item/[id]/route.ts
@@ -41,7 +41,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
       .limit(1);
 
     if (!rows[0]) {
-      return applySecurityHeaders(NextResponse.json({ error: "Catalog item not found." }, { status: 404 }));
+      return applySecurityHeaders(
+        NextResponse.json({ error: "Catalog item not found." }, { status: 404 }),
+      );
     }
 
     return applySecurityHeaders(NextResponse.json(rows[0]));

--- a/apps/web/src/app/docs/tabs/DocsTabMcp.tsx
+++ b/apps/web/src/app/docs/tabs/DocsTabMcp.tsx
@@ -1,6 +1,6 @@
+import { McpSnippetPreview } from "@/components/docs/McpSnippetPreview";
 import type { AppLocale } from "@/i18n/config";
 import { localizePath } from "@/i18n/locale-routing";
-import { McpSnippetPreview } from "@/components/docs/McpSnippetPreview";
 import { ShieldCheck, TerminalSquare, Wrench } from "lucide-react";
 import Link from "next/link";
 
@@ -146,7 +146,8 @@ const MCP_COPY = {
     statusBody:
       "这是一个扎实的 phase-1 MCP 面：目录搜索、单项查询、目标指导、安装规划、应用、备份列表、rollback，以及本地 stack 的保存与加载，都复用了真实的 CLI 服务层。",
     commandTitle: "启动命令",
-    commandBody: "使用 npx vibebasket mcp serve 在本地启动 MCP 服务。客户端应通过 stdio 连接，而不是 HTTP。",
+    commandBody:
+      "使用 npx vibebasket mcp serve 在本地启动 MCP 服务。客户端应通过 stdio 连接，而不是 HTTP。",
     snippetsTitle: "原生配置片段",
     snippetsBody:
       "通过 targets.get_mcp_snippet 请求目标原生片段。下面这些示例展示了几个代表性客户端的准确 merge 形状。",
@@ -358,7 +359,9 @@ export function DocsTabMcp({ locale }: { locale: AppLocale }) {
             <Wrench className="h-5 w-5 text-[#7dd3fc]" />
             <h2 className="text-xl font-semibold text-foreground">{copy.snippetsTitle}</h2>
           </div>
-          <p className="mb-6 max-w-3xl text-sm leading-relaxed text-[#bdc9c2]">{copy.snippetsBody}</p>
+          <p className="mb-6 max-w-3xl text-sm leading-relaxed text-[#bdc9c2]">
+            {copy.snippetsBody}
+          </p>
           <McpSnippetPreview
             targets={EXAMPLE_TARGETS.map(({ key, targetId }) => ({
               id: targetId,


### PR DESCRIPTION
## Summary
- apply the remaining Biome formatting and import-order fixes introduced by the local MCP surface
- replace unsafe non-null assertions in MCP applyInstall with an explicit guard
- confirm the full local `pnpm verify:ci` chain passes again

## Verification
- pnpm verify:ci