### PR TITLE
release: prepare vibebasket 0.9.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Bundle trusted MCP servers, agent skills, and project rules into one shareable install command. Apply across 24 AI IDEs and CLI tools with a single link.
 
-[![Version](https://img.shields.io/badge/version-0.9.5-blue)](package.json)
+[![Version](https://img.shields.io/badge/version-0.9.6-blue)](package.json)
 [![npm](https://img.shields.io/npm/v/vibebasket)](https://www.npmjs.com/package/vibebasket)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](tsconfig.base.json)
 [![CI](https://img.shields.io/badge/ci-github_actions-green)](https://github.com/mhmtayberk/VibeBasket/actions/workflows/ci.yml)

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -16,6 +16,11 @@ The CLI is built for the last mile:
 npx vibebasket apply https://vibebasket.dev/api/bundle/<bundle-id>
 ```
 
+Use the hosted app to generate a bundle:
+
+- App: https://vibebasket.dev
+- Docs: https://github.com/mhmtayberk/VibeBasket#readme
+
 ## Commands
 
 ```bash
@@ -51,6 +56,13 @@ Current limitation:
 
 - cloud/profile-backed stack save is not linked in the local MCP yet, so use the VibeBasket website for that path
 
+Typical MCP flow:
+
+1. Ask your AI IDE to search the VibeBasket catalog
+2. Ask it to preview target-native MCP config snippets for Cursor, Codex CLI, Continue, or other supported targets
+3. Ask it to plan or apply the install
+4. Provide runtime credentials only on your own machine if a selected MCP server needs them
+
 ## How Secrets Work
 
 - Secrets required by MCP servers are resolved locally on your machine.
@@ -69,6 +81,23 @@ VIBEBASKET_API_URL=https://your-domain.com npx vibebasket search postgresql
 ```
 
 The same override works for bundle apply flows that use hosted URLs.
+
+## Local Bundle Files
+
+`apply` also accepts a local bundle JSON file.
+
+Minimal example:
+
+```json
+{
+  "schemaVersion": "0.1",
+  "scope": "user",
+  "targets": ["cursor"],
+  "items": []
+}
+```
+
+Use `scope: "project"` when a target supports project-scoped config and you want VibeBasket to write into the current repository context instead of user-level config.
 
 ## Notes
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibebasket",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Local installer and inspection CLI for VibeBasket bundles",
   "main": "./dist/index.js",
   "files": ["dist", "README.md"],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "private": true,
   "scripts": {
     "dev": "\"$npm_node_execpath\" ../../scripts/run-next.mjs dev --webpack",


### PR DESCRIPTION
## Summary
- bump CLI and web package versions to 0.9.6 for release alignment
- refresh the npm-facing CLI README with local MCP guidance and a local bundle file example
- update the root README version badge before publishing

## Verification
- `pnpm verify:ci`
- `pnpm --filter vibebasket build`
- `pnpm --filter vibebasket test`
- `cd apps/cli && npm pack --dry-run`